### PR TITLE
Feat/#5 공통 스타일 & 공통 컴포넌트 구현

### DIFF
--- a/src/components/CommonButton.tsx
+++ b/src/components/CommonButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { TouchableOpacity, Text, ViewStyle, TextStyle } from 'react-native';
+import commonStyles from '../styles/commonStyles';
+
+interface CommonButtonProps {
+	title: string;
+	onPress: () => void;
+	buttonStyle?: ViewStyle;
+	textStyle?: TextStyle;
+}
+
+const CommonButton: React.FC<CommonButtonProps> = ({ title, onPress, buttonStyle, textStyle }) => {
+	return (
+		<TouchableOpacity
+			style={[commonStyles.mainButton, buttonStyle]}
+			onPress={onPress}
+			activeOpacity={0.8}
+		>
+			<Text style={[commonStyles.mainButtonText, textStyle]}>{title}</Text>
+		</TouchableOpacity>
+	);
+};
+
+export default CommonButton;

--- a/src/components/CommonButton.tsx
+++ b/src/components/CommonButton.tsx
@@ -2,21 +2,45 @@ import React from 'react';
 import { TouchableOpacity, Text, ViewStyle, TextStyle } from 'react-native';
 import commonStyles from '../styles/commonStyles';
 
+type ButtonSize = 'large' | 'medium' | 'small';
+
 interface CommonButtonProps {
 	title: string;
 	onPress: () => void;
+	size?: ButtonSize;
 	buttonStyle?: ViewStyle;
 	textStyle?: TextStyle;
 }
 
-const CommonButton: React.FC<CommonButtonProps> = ({ title, onPress, buttonStyle, textStyle }) => {
+const CommonButton: React.FC<CommonButtonProps> = ({
+	title,
+	onPress,
+	size = 'medium',
+	buttonStyle,
+	textStyle,
+}) => {
+	const sizeStyles = {
+		large: {
+			container: commonStyles.buttonLarge,
+			text: commonStyles.buttonTextLarge,
+		},
+		medium: {
+			container: commonStyles.buttonMedium,
+			text: commonStyles.buttonTextMedium,
+		},
+		small: {
+			container: commonStyles.buttonSmall,
+			text: commonStyles.buttonTextSmall,
+		},
+	};
+
 	return (
 		<TouchableOpacity
-			style={[commonStyles.mainButton, buttonStyle]}
+			style={[sizeStyles[size].container, buttonStyle]}
 			onPress={onPress}
 			activeOpacity={0.8}
 		>
-			<Text style={[commonStyles.mainButtonText, textStyle]}>{title}</Text>
+			<Text style={[sizeStyles[size].text, textStyle]}>{title}</Text>
 		</TouchableOpacity>
 	);
 };

--- a/src/components/ScreenContainer.tsx
+++ b/src/components/ScreenContainer.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, ViewStyle, ViewProps, View } from 'react-native';
+import colors from '../styles/colors';
+import spacing from '../styles/spacing';
+
+interface ScreenContainerProps extends ViewProps {
+	children: React.ReactNode;
+	style?: ViewStyle;
+	noPadding?: boolean;
+	backgroundColor?: string;
+}
+
+const ScreenContainer = ({
+	children,
+	style,
+	noPadding = false,
+	backgroundColor = colors.bgGray,
+	...props
+}: ScreenContainerProps) => {
+	return (
+		<SafeAreaView style={[styles.safeArea, { backgroundColor }]}>
+			<View style={[styles.container, noPadding && styles.noPadding, style]} {...props}>
+				{children}
+			</View>
+		</SafeAreaView>
+	);
+};
+
+const styles = StyleSheet.create({
+	safeArea: {
+		flex: 1,
+	},
+	container: {
+		flex: 1,
+		paddingHorizontal: spacing.l,
+		paddingVertical: spacing.m,
+	},
+	noPadding: {
+		paddingHorizontal: 0,
+		paddingVertical: 0,
+	},
+});
+
+export default ScreenContainer;

--- a/src/screens/Exchange/GPSView.tsx
+++ b/src/screens/Exchange/GPSView.tsx
@@ -1,9 +1,20 @@
-import { Text } from "react-native";
+/* eslint-disable prettier/prettier */
+import { View, Text } from 'react-native';
+import CommonButton from '../../components/CommonButton';
+import commonStyles from '../../styles/commonStyles';
+import ScreenContainer from '../../components/ScreenContainer';
 
 export default function GPSView() {
-    return (
-        <Text>
-            웹소켓 교환
-        </Text>
-    )
-};
+	return (
+		<ScreenContainer>
+			<View style={commonStyles.sectionBox}>
+				<Text style={commonStyles.titleText}>화이팅</Text>
+				<Text style={commonStyles.bodyBoldText}>화이팅</Text>
+				<Text style={commonStyles.bodyText}>화이팅</Text>
+				<Text style={commonStyles.errorText}>화이팅</Text>
+				<Text style={commonStyles.subtitleText}>화이팅</Text>
+			</View>
+			<CommonButton title="하이" onPress={() => console.log('버튼 클릭')} />
+		</ScreenContainer>
+	);
+}

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -1,0 +1,20 @@
+export const Colors = {
+	primary: '#05AA5B',
+	lightGreen: '#24D785',
+	paleGreen: 'rgba(238, 249, 243, 0.6)',
+	darkGreen: '#004131',
+
+	white: '#FFFFFF',
+	black: '#000000',
+
+	grayscaleGray1: '#F3F5F7',
+	grayscaleGray2: '#EFEFF0',
+	grayscaleGray3: '#E9E9E9',
+	grayscaleGray4: '#BBBBBD',
+	grayscaleGray5: '#929294',
+	grayscaleGray6: '#828385',
+	grayscaleGray7: '#5D5D5D',
+
+	bgWhite: '#FFFFFF',
+	bgGray: '#EDEFF2',
+};

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -1,4 +1,4 @@
-export const Colors = {
+const colors = {
 	primary: '#05AA5B',
 	lightGreen: '#24D785',
 	paleGreen: 'rgba(238, 249, 243, 0.6)',
@@ -18,3 +18,5 @@ export const Colors = {
 	bgWhite: '#FFFFFF',
 	bgGray: '#EDEFF2',
 };
+
+export default colors;

--- a/src/styles/commonStyles.ts
+++ b/src/styles/commonStyles.ts
@@ -4,16 +4,40 @@ import typography from './typography';
 import colors from './colors';
 
 const commonStyles = StyleSheet.create({
-	mainButton: {
+	buttonLarge: {
 		backgroundColor: colors.primary,
 		paddingVertical: 16,
-		paddingHorizontal: 20,
 		borderRadius: 8,
 		alignItems: 'center',
 	},
-	mainButtonText: {
+	buttonMedium: {
+		backgroundColor: colors.primary,
+		width: 160,
+		paddingVertical: 14,
+		borderRadius: 8,
+		alignItems: 'center',
+	},
+	buttonSmall: {
+		backgroundColor: colors.primary,
+		width: 90,
+		paddingVertical: 10,
+		borderRadius: 8,
+		alignItems: 'center',
+	},
+
+	buttonTextLarge: {
 		color: colors.white,
 		fontSize: 16,
+		fontWeight: '600',
+	},
+	buttonTextMedium: {
+		color: colors.white,
+		fontSize: 15,
+		fontWeight: '600',
+	},
+	buttonTextSmall: {
+		color: colors.white,
+		fontSize: 14,
 		fontWeight: '600',
 	},
 	sectionBox: {

--- a/src/styles/commonStyles.ts
+++ b/src/styles/commonStyles.ts
@@ -1,0 +1,59 @@
+import { StyleSheet } from 'react-native';
+import spacing from './spacing';
+import typography from './typography';
+import colors from './colors';
+
+const commonStyles = StyleSheet.create({
+	mainButton: {
+		backgroundColor: colors.primary,
+		paddingVertical: 16,
+		paddingHorizontal: 20,
+		borderRadius: 8,
+		alignItems: 'center',
+	},
+	mainButtonText: {
+		color: colors.white,
+		fontSize: 16,
+		fontWeight: '600',
+	},
+	sectionBox: {
+		backgroundColor: colors.bgGray,
+		borderRadius: 12,
+		padding: spacing.m,
+		marginBottom: spacing.m,
+	},
+	row: {
+		flexDirection: 'row',
+		alignItems: 'center',
+	},
+	center: {
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	titleText: {
+		...typography.h1,
+		color: colors.black,
+	},
+	subtitleText: {
+		...typography.h2,
+		color: colors.black,
+	},
+	bodyText: {
+		...typography.body,
+		color: colors.grayscaleGray7,
+	},
+	bodyBoldText: {
+		...typography.bodyBold,
+		color: colors.black,
+	},
+	captionText: {
+		...typography.caption,
+		color: colors.grayscaleGray5,
+	},
+	errorText: {
+		...typography.body,
+		color: 'red',
+	},
+});
+
+export default commonStyles;

--- a/src/styles/commonStyles.ts
+++ b/src/styles/commonStyles.ts
@@ -17,7 +17,7 @@ const commonStyles = StyleSheet.create({
 		fontWeight: '600',
 	},
 	sectionBox: {
-		backgroundColor: colors.bgGray,
+		backgroundColor: colors.white,
 		borderRadius: 12,
 		padding: spacing.m,
 		marginBottom: spacing.m,
@@ -40,7 +40,7 @@ const commonStyles = StyleSheet.create({
 	},
 	bodyText: {
 		...typography.body,
-		color: colors.grayscaleGray7,
+		color: colors.black,
 	},
 	bodyBoldText: {
 		...typography.bodyBold,

--- a/src/styles/spacing.ts
+++ b/src/styles/spacing.ts
@@ -1,0 +1,14 @@
+const spacing = {
+	none: 0,
+	xs: 4,
+	s: 8,
+	sm: 12,
+	m: 16,
+	ml: 20,
+	l: 24,
+	xl: 32,
+	xxl: 40,
+	xxxl: 48,
+};
+
+export default spacing;

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,4 +1,10 @@
-const typography = {
+import { TextStyle } from 'react-native';
+
+type TypographyStyle = {
+	[key: string]: TextStyle;
+};
+
+const typography: TypographyStyle = {
 	h1: {
 		fontSize: 32,
 		fontWeight: '700',

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,0 +1,40 @@
+const typography = {
+	h1: {
+		fontSize: 32,
+		fontWeight: '700',
+		lineHeight: 40,
+	},
+	h2: {
+		fontSize: 24,
+		fontWeight: '600',
+		lineHeight: 32,
+	},
+	h3: {
+		fontSize: 20,
+		fontWeight: '500',
+		lineHeight: 28,
+	},
+	body: {
+		fontSize: 16,
+		fontWeight: '400',
+		lineHeight: 24,
+	},
+	bodyBold: {
+		fontSize: 16,
+		fontWeight: '600',
+		lineHeight: 24,
+	},
+	caption: {
+		fontSize: 12,
+		fontWeight: '400',
+		lineHeight: 16,
+	},
+	button: {
+		fontSize: 16,
+		fontWeight: '600',
+		lineHeight: 20,
+		textAlign: 'center',
+	},
+};
+
+export default typography;


### PR DESCRIPTION
## 📝 작업 내용

### 공통으로 사용될 상수 정의
- 많이 사용될만한 색상, 간격, 폰트를 공통 스타일로 분류하였습니다.

### commonStyle 정의
- 공통으로 많이 사용될 스타일에 대해 정의하였습니다.
- 사용 예는 다음과 같습니다.
```js
	<Text style={commonStyles.bodyText}>화이팅</Text>
	<Text style={commonStyles.errorText}>화이팅</Text>
	<Text style={commonStyles.subtitleText}>화이팅</Text>
```
- Text와 버튼, Section에 대한 스타일로만 일단 구성해뒀습니다.

### 공통 컴포넌트 구현
- 자주 사용될 메인 하단 버튼을 구현하였습니다.
- 모든 스크린에 사용될 ScreenContainer를 구현하였습니다.

<img src="https://github.com/user-attachments/assets/c768910f-b75b-4805-a0e5-41d312484e5e" alt="image" width="300">


## 🔍 참고 자료 (option)

트러블 슈팅 공유 합니다..
폰트 웨이트를 스타일시트에 도입할때 문제가 되더라고요..

🔧 문제 요약
React Native의 TextStyle은 fontWeight 등의 속성 타입이 엄격하게 string 리터럴 타입으로 제한되어 있음에도 불구하고,
초기에는 fontWeight 값을 숫자(예: 700)로 지정해 타입 오류가 발생하였습니다.

🧨 에러 원인
fontWeight는 숫자처럼 보이지만 실제로는 '100' | '200' | ... | '900' 등과 같은 문자열로 작성되어야 합니다.

// 잘못된 예시 ❌
fontWeight: 700
// 올바른 예시 ✅
fontWeight: '700'
StyleSheet.create()는 타입 검사를 엄격히 수행하므로 숫자 타입은 에러 발생

commonStyles.ts에서 ...typography.h1 등의 spread 문법 사용 시에도 타입 충돌이 발생함

✅ 해결 방법
typography.ts 내 fontWeight 값을 모두 문자열로 수정 ('700', '400' 등)

typography 객체의 타입을 명확히 지정하여 TextStyle로 인식되도록 개선


## 💬 기타 사항 (option)

- ScreenContainer import시 동명의 모듈이 있으니 유의해야함.
- 나중에 스타일링 하실때 자유롭게 공통 컴포넌트에 추가해주셔도 좋을 것 같습니다.
- GPSView는 임의로 스타일 예시용도로 올려둡니다..
- 매콤한 코드리뷰 부탁드립니다.
