### PR TITLE
Feat/#10 명함 숨김, 삭제 바텀시트 모달 구현

### DIFF
--- a/src/components/ScreenContainer.tsx
+++ b/src/components/ScreenContainer.tsx
@@ -14,7 +14,7 @@ const ScreenContainer = ({
 	children,
 	style,
 	noPadding = false,
-	backgroundColor = colors.bgGray,
+	backgroundColor = colors.white,
 	...props
 }: ScreenContainerProps) => {
 	return (

--- a/src/components/cardList/CardBottomSheet.tsx
+++ b/src/components/cardList/CardBottomSheet.tsx
@@ -1,0 +1,137 @@
+import { Alert, Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
+import Entypo from '@expo/vector-icons/Entypo';
+
+import CommonButton from './../CommonButton';
+import colors from '../../styles/Colors';
+import { useCardStore } from '../../store/cardStore';
+import { useModalStore } from '../../store/modalStore';
+
+export default function CardBottomSheet() {
+	const { cardList, hideCard, deleteCard } = useCardStore();
+	const { isModalOpen, selectedCardId, closeModal } = useModalStore();
+
+	const [selectedCard] = cardList.filter(card => card.id === selectedCardId);
+
+	const handleHidingCard = (cardId: number | null) => {
+		if (cardId === null) return;
+		try {
+			const newStatus = !selectedCard.status;
+			if (!newStatus) {
+				// 명함을 숨기는 경우
+				Alert.alert('선택한 명함을 숨김 처리합니다.', '정말 숨기시겠습니까?', [
+					{
+						text: '확인',
+						onPress: () => {
+							hideCard(cardId, newStatus);
+							Alert.alert('명함이 숨김 처리되었습니다');
+						},
+					},
+					{ text: '취소' },
+				]);
+			} else {
+				// 명함을 숨김 해제하는 경우
+				hideCard(cardId, newStatus);
+				Alert.alert('명함 숨김이 해제되었습니다');
+			}
+		} catch {
+			Alert.alert('처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
+		}
+		closeModal();
+	};
+	const handleDeletingCard = (cardId: number | null) => {
+		if (cardId === null) return;
+		try {
+			Alert.alert('선택한 명함을 삭제합니다.', '정말 삭제하시겠습니까?', [
+				{
+					text: '확인',
+					onPress: () => {
+						deleteCard(cardId);
+						Alert.alert('명함이 삭제되었습니다.');
+					},
+				},
+				{ text: '취소' },
+			]);
+		} catch {
+			Alert.alert('처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
+		}
+		closeModal();
+	};
+	return (
+		<Modal
+			animationType="slide"
+			transparent={true}
+			visible={isModalOpen}
+			onRequestClose={closeModal}
+		>
+			<View
+				style={{
+					flex: 1,
+					justifyContent: 'flex-end',
+				}}
+			>
+				<View style={styles.modalView}>
+					<TouchableOpacity
+						style={{ width: '100%', alignItems: 'flex-end', paddingHorizontal: 10 }}
+						onPress={closeModal}
+					>
+						<Entypo name="cross" size={30} color={colors.darkGreen} />
+					</TouchableOpacity>
+					<View style={styles.buttonWrapper}>
+						<CommonButton
+							title={
+								selectedCard !== undefined && !selectedCard.status
+									? '명함 숨김 해제하기'
+									: '명함 리스트에서 숨김'
+							}
+							onPress={() => handleHidingCard(selectedCardId)}
+							buttonStyle={styles.button}
+							textStyle={styles.textStyle}
+							size="large"
+						/>
+						<CommonButton
+							title="명함 리스트에서 삭제"
+							onPress={() => handleDeletingCard(selectedCardId)}
+							buttonStyle={{ ...styles.button, backgroundColor: colors.darkGreen }}
+							textStyle={styles.textStyle}
+							size="large"
+						/>
+					</View>
+				</View>
+			</View>
+		</Modal>
+	);
+}
+
+const styles = StyleSheet.create({
+	modalView: {
+		width: '100%',
+		backgroundColor: 'white',
+		borderRadius: 20,
+		alignItems: 'center',
+		paddingVertical: 15,
+		shadowColor: '#000',
+		shadowOffset: {
+			width: 0,
+			height: 2,
+		},
+		shadowOpacity: 0.25,
+		shadowRadius: 4,
+	},
+	buttonWrapper: {
+		width: '100%',
+		alignItems: 'center',
+		marginTop: 10,
+		marginBottom: 30,
+	},
+	button: {
+		width: '85%',
+		paddingVertical: 18,
+		marginBottom: 7,
+	},
+	textStyle: {
+		color: 'white',
+		fontWeight: 'bold',
+		textAlign: 'center',
+		fontSize: 18,
+	},
+});

--- a/src/components/cardList/CardBottomSheet.tsx
+++ b/src/components/cardList/CardBottomSheet.tsx
@@ -23,7 +23,7 @@ export default function CardBottomSheet() {
 						text: '확인',
 						onPress: () => {
 							hideCard(cardId, newStatus);
-							Alert.alert('명함이 숨김 처리되었습니다');
+							Alert.alert('명함이 숨김 처리되었습니다.');
 						},
 					},
 					{ text: '취소' },
@@ -31,7 +31,7 @@ export default function CardBottomSheet() {
 			} else {
 				// 명함을 숨김 해제하는 경우
 				hideCard(cardId, newStatus);
-				Alert.alert('명함 숨김이 해제되었습니다');
+				Alert.alert('명함 숨김이 해제되었습니다.');
 			}
 		} catch {
 			Alert.alert('처리에 실패했습니다. 잠시 후 다시 시도해주세요.');

--- a/src/components/cardList/CardItem.tsx
+++ b/src/components/cardList/CardItem.tsx
@@ -5,8 +5,10 @@ import { Ionicons, AntDesign } from '@expo/vector-icons';
 import colors from '../../styles/Colors';
 import typography from '../../styles/typography';
 import { ICardItem } from '../../model/cardItem';
+import { useModalStore } from '../../store/modalStore';
 
 export default function CardItem(props: ICardItem) {
+	const { isModalOpen, selectedCardId, openModal } = useModalStore();
 	const [isImportant, setIsImportant] = useState(props.favorite);
 	const toggleHeart = () => {
 		setIsImportant(prev => {
@@ -14,12 +16,17 @@ export default function CardItem(props: ICardItem) {
 			return !prev;
 		});
 	};
+
 	return (
 		<Pressable
+			onLongPress={() => openModal(props.id)}
 			style={({ pressed }) => [
 				styles.cardItem,
 				{
-					backgroundColor: pressed ? colors.paleDarkGreen : colors.paleGreen,
+					backgroundColor:
+						pressed || (isModalOpen && selectedCardId === props.id)
+							? colors.paleDarkGreen
+							: colors.paleGreen,
 				},
 			]}
 		>

--- a/src/screens/CardList/CardListView.tsx
+++ b/src/screens/CardList/CardListView.tsx
@@ -7,9 +7,9 @@ import ScreenContainer from '../../components/ScreenContainer';
 import SearchInput from '../../components/cardList/SearchInput';
 import SortDropDown from '../../components/cardList/SortDropDown';
 import CardSectionList from '../../components/cardList/CardSectionList';
+import CommonButton from '../../components/CommonButton';
 import { useCardStore } from '../../store/cardStore';
 import { dummyData } from '../../model/cardItem';
-import CommonButton from '../../components/CommonButton';
 
 // 안드로이드 환경에서도 레이아웃 애니메이션 동작하도록 설정
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -25,7 +25,7 @@ export default function CardListView({ navigation }: any) {
 
 	return (
 		<ScreenContainer>
-			<View style={{ ...commonStyles.sectionBox, height: '100%' }}>
+			<View style={{ height: '100%' }}>
 				<Text style={styles.headerTitle}>명함 리스트</Text>
 				<SearchInput />
 				<View style={styles.mainLabelWrapper}>

--- a/src/screens/CardList/CardListView.tsx
+++ b/src/screens/CardList/CardListView.tsx
@@ -8,6 +8,7 @@ import SearchInput from '../../components/cardList/SearchInput';
 import SortDropDown from '../../components/cardList/SortDropDown';
 import CardSectionList from '../../components/cardList/CardSectionList';
 import CommonButton from '../../components/CommonButton';
+import CardBottomSheet from '../../components/cardList/CardBottomSheet';
 import { useCardStore } from '../../store/cardStore';
 import { dummyData } from '../../model/cardItem';
 
@@ -46,6 +47,7 @@ export default function CardListView({ navigation }: any) {
 					<CardSectionList />
 				)}
 			</View>
+			<CardBottomSheet />
 		</ScreenContainer>
 	);
 }

--- a/src/store/cardStore.ts
+++ b/src/store/cardStore.ts
@@ -13,6 +13,8 @@ type CardStore = {
 	setCardList: (cards: ICardItem[]) => void;
 	filterCardList: () => void;
 	sortCardList: (option: 'latest' | 'name') => void;
+	hideCard: (cardId: number, newStatus: boolean) => void;
+	deleteCard: (cardId: number) => void;
 };
 
 export const useCardStore = create<CardStore>((set, get) => ({
@@ -43,5 +45,17 @@ export const useCardStore = create<CardStore>((set, get) => ({
 		if (option === 'latest') tempList.sort((a, b) => b.created_at - a.created_at);
 		else tempList.sort((a, b) => (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1));
 		get().setCardList(tempList);
+	},
+	hideCard: (cardId, newStatus) => {
+		// 명함 숨김 상태 업데이트 로직
+		const newList = [...get().cardList].map(card =>
+			card.id === cardId ? { ...card, status: newStatus } : card
+		);
+		get().setCardList(newList);
+	},
+	deleteCard: cardId => {
+		// 명함 삭제 로직
+		const newList = [...get().cardList].filter(card => card.id !== cardId);
+		get().setCardList(newList);
 	},
 }));

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+type ModalStore = {
+	isModalOpen: boolean;
+	selectedCardId: number | null;
+	openModal: (cardId: number) => void;
+	closeModal: () => void;
+};
+
+export const useModalStore = create<ModalStore>(set => ({
+	isModalOpen: false,
+	selectedCardId: null,
+	openModal: cardId => set({ isModalOpen: true, selectedCardId: cardId }),
+	closeModal: () => set({ isModalOpen: false, selectedCardId: null }),
+}));


### PR DESCRIPTION
## 📝 작업 내용

- 명함 숨김 여부 업데이트 및 명함 삭제를 위한 모달을 구현했습니다.
- 명함 리스트 뷰와 명함 디테일 뷰에서 같은 모달 컴포넌트를 사용할 예정이라 `modalStore`를 따로 생성하고, 모달 `open/close` 상태와 모달을 오픈한 `명함 id`를 전역으로 관리할 수 있도록 처리했습니다.

## 🔍 참고 자료 (option)

- 숨김/삭제 기능 동작은 아래 참고해주세요!
- 아래 동작 + 모달이 열려있는 동안 선택된 명함에 바뀐 배경색 유지되도록 스타일 추가해놨습니다!

![명함리스트 모달 동작화면](https://github.com/user-attachments/assets/614c1fe7-8c33-42aa-9f8e-6039520f417f)

## 💬 기타 사항 (option)

- 모달 외부 영역을 터치할 경우 자동으로 닫히도록 하면 좋을 것 같은데,, 일단 닫기 버튼 추가해서 만들어놨어요!
- 카톡으로 공유드린 expo SDK 버전 업데이트 문제 관련해서.. 로컬에서 개별적으로 업데이트 해보려고 했는데 왜인지 의존성 충돌이 굉장히 많이 나더라구요,, 이번주 중으로 브랜치 파서 다시 한번 도전해보겠습니다ㅠㅠ
우선 시뮬레이터나 에뮬레이터 돌리면서 개발 진행해주시면 될 것 같아요! 다들 파이팅입니다~~

---
Closes #10 