### PR TITLE
Feat/#25 QR Scanner 구현

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,29 +1,39 @@
 {
-  "expo": {
-    "name": "scannect",
-    "slug": "scannect",
-    "scheme": "scannect",
-    "version": "1.0.0",
-    "orientation": "portrait",
-    "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
-    "newArchEnabled": true,
-    "splash": {
-      "image": "./assets/splash-icon.png",
-      "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
-    },
-    "ios": {
-      "supportsTablet": true
-    },
-    "android": {
-      "adaptiveIcon": {
-        "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
-      }
-    },
-    "web": {
-      "favicon": "./assets/favicon.png"
-    }
-  }
+	"expo": {
+		"name": "scannect",
+		"slug": "scannect",
+		"scheme": "scannect",
+		"version": "1.0.0",
+		"orientation": "portrait",
+		"icon": "./assets/icon.png",
+		"userInterfaceStyle": "light",
+		"newArchEnabled": true,
+		"splash": {
+			"image": "./assets/splash-icon.png",
+			"resizeMode": "contain",
+			"backgroundColor": "#ffffff"
+		},
+		"ios": {
+			"supportsTablet": true
+		},
+		"android": {
+			"adaptiveIcon": {
+				"foregroundImage": "./assets/adaptive-icon.png",
+				"backgroundColor": "#ffffff"
+			}
+		},
+		"web": {
+			"favicon": "./assets/favicon.png"
+		},
+		"plugins": [
+			[
+				"expo-camera",
+				{
+					"cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
+					"microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
+					"recordAudioAndroid": true
+				}
+			]
+		]
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native-stack": "^7.3.9",
         "axios": "^1.8.4",
         "expo": "~53.0.8",
+        "expo-camera": "~16.1.6",
         "expo-file-system": "^18.1.10",
         "expo-location": "~18.1.4",
         "expo-sharing": "^13.1.5",
@@ -6658,6 +6659,25 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.6.tgz",
+      "integrity": "sha512-caVSfoTUaayYhH5gicrXWCgBQIVrotPOH3jUDr4vhN5VQDB/+TWaY+le2nQtNXgQEz14Af+H/TNvYpvvNj5Ktg==",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-native-screens": "^4.10.0",
     "react-native-svg": "^15.11.2",
     "react-native-web": "^0.20.0",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "expo-camera": "~16.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/qrcode/QRCodeSection.tsx
+++ b/src/components/qrcode/QRCodeSection.tsx
@@ -12,8 +12,10 @@ interface IQRCodeProp {
 }
 
 export default function QRCodeSection({ value }: IQRCodeProp) {
-	const { qrRef, onQRShare } = useQRCode();
+	const { qrRef, shareQR } = useQRCode();
 	const logoFile = require('../../assets/teamLogo.jpeg');
+
+	const handlePress = () => shareQR();
 
 	return (
 		<>
@@ -32,7 +34,7 @@ export default function QRCodeSection({ value }: IQRCodeProp) {
 			<Text style={[commonStyles.bodyBoldText, { marginBottom: spacing.l }]}>
 				QR코드를 공유하고 내 명함을 전달해보세요!
 			</Text>
-			<CommonButton title="내 명함 공유하러 가기" onPress={() => onQRShare()} />
+			<CommonButton title="내 명함 공유하러 가기" onPress={handlePress} />
 		</>
 	);
 }

--- a/src/hooks/useQRCode.ts
+++ b/src/hooks/useQRCode.ts
@@ -1,12 +1,16 @@
+import { useNavigation } from '@react-navigation/native';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import { useRef } from 'react';
+import { Alert } from 'react-native';
 
 export function useQRCode() {
 	const qrRef = useRef<any>(null);
+	const scannedRef = useRef(false);
+	const navigation = useNavigation<any>();
 
-	const onQRShare = async () => {
-		// qr코드 BASE64 인코딩 후 파일 공유
+	/** qr코드 Base64 인코딩 후 파일 저장 및 외부로 공유하는 함수 */
+	const shareQR = async () => {
 		console.log('qr 공유 중...');
 		qrRef.current?.toDataURL(async (data: string) => {
 			const filename = FileSystem.documentDirectory + 'scannect_qrcode.png';
@@ -21,5 +25,48 @@ export function useQRCode() {
 			}
 		});
 	};
-	return { qrRef, onQRShare };
+
+	/** 바코드 스캔 상태 초기화 함수 */
+	const resetScan = () => (scannedRef.current = false);
+
+	/** 스캔한 명함을 저장하고 해당 명함 상세 페이지로 이동하는 함수 */
+	const saveCard = (qrCardId: number) => {
+		console.log(qrCardId, '저장 중...');
+		/* 명함 저장 */
+		/* 네비게이션 */
+		navigation.pop();
+		navigation.navigate('CardListTab', { screen: 'CardDetail', params: { cardId: qrCardId } });
+	};
+
+	/** 바코드 스캔 데이터 저장 함수 */
+	const scanQR = (data: string) => {
+		if (scannedRef.current) return;
+		scannedRef.current = true;
+
+		// qr코드 유효성 검사
+		if (!data.startsWith('scannect://')) {
+			Alert.alert('유효하지 않은 QR 코드입니다.', 'SCANNECT 명함 QR코드를 인식해주세요!', [
+				{
+					text: '확인',
+					onPress: resetScan,
+				},
+			]);
+		} else {
+			// 링크 url에서 cardId 정보 get
+			const parsedURL = data.split('/');
+			const scannedCardId = parseInt(parsedURL[parsedURL.length - 1]);
+
+			console.log(scannedRef.current, scannedCardId);
+
+			Alert.alert(`명함 스캔 완료! id: ${scannedCardId}`, '스캔한 명함을 저장합니다...', [
+				{
+					text: '저장',
+					onPress: () => saveCard(scannedCardId),
+				},
+				{ text: '취소', onPress: resetScan },
+			]);
+		}
+	};
+
+	return { qrRef, shareQR, scanQR };
 }

--- a/src/navigations/ExchangeStack.tsx
+++ b/src/navigations/ExchangeStack.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import GPSView from '../screens/Exchange/GPSView';
 import QRGenerationView from '../screens/Exchange/QRGenerationView';
+import QRScanView from '../screens/Exchange/QRScanView';
 
 const Stack = createNativeStackNavigator();
 
@@ -14,11 +15,7 @@ export default function ExchangeStack() {
 				component={QRGenerationView}
 				options={{ title: 'QR 코드 생성' }}
 			/>
-			<Stack.Screen
-				name="QRScan"
-				component={QRGenerationView}
-				options={{ title: 'QR 코드 스캔' }}
-			/>
+			<Stack.Screen name="QRScan" component={QRScanView} options={{ title: 'QR 코드 스캔' }} />
 			<Stack.Screen name="PaperScan" component={QRGenerationView} options={{ title: 'OCR 교환' }} />
 		</Stack.Navigator>
 	);

--- a/src/screens/Exchange/QRGenerationView.tsx
+++ b/src/screens/Exchange/QRGenerationView.tsx
@@ -5,11 +5,12 @@ import QRCodeSection from '../../components/qrcode/QRCodeSection';
 import commonStyles from '../../styles/commonStyles';
 import spacing from '../../styles/spacing';
 import colors from '../../styles/Colors';
+import { useMypageStore } from '../../store/useMyPageStore';
 
 export default function QRGenerationView() {
 	const exampleID = 1; // QR 생성을 위한 id 데이터
 	const qrUrl = `scannect://cardlist-tab/card-detail/${exampleID}`; // url은 컨벤션상 kebab-case로 작성 -> 인식하려면 Navigation Linking 설정 필요
-	//const qrUrl = 'https://github.com/Team-Architekton/Scannect_FE'; // qr 생성 테스트를 위한 임시 url
+	const { selectedCard } = useMypageStore();
 
 	return (
 		<ScreenContainer>
@@ -20,7 +21,7 @@ export default function QRGenerationView() {
 						이제 나만의 명함을 저장하고 공유할 수 있어요.
 					</Text>
 					<Text style={[commonStyles.captionText, styles.exchangedCardInfo]}>
-						프론트엔드 개발자
+						{selectedCard?.title}
 					</Text>
 				</View>
 				<QRCodeSection value={qrUrl} />

--- a/src/screens/Exchange/QRScanView.tsx
+++ b/src/screens/Exchange/QRScanView.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function QRScanView() {
+	return (
+		<View>
+			<Text>스캐너어어</Text>
+		</View>
+	);
+}

--- a/src/screens/Exchange/QRScanView.tsx
+++ b/src/screens/Exchange/QRScanView.tsx
@@ -1,15 +1,13 @@
 import { Text, TouchableOpacity, View, StyleSheet, Alert } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 export default function QRScanView({ navigation }: any) {
-	const [scanned, setScanned] = useState(false);
+	const scannedRef = useRef(false);
 	const [permission, requestPermission] = useCameraPermissions();
 
-	/** 바코드 스캔 초기화 함수 */
-	const handleResetScan = () => {
-		setScanned(false);
-	};
+	/** 바코드 스캔 상태 초기화 함수 */
+	const handleResetScan = () => (scannedRef.current = false);
 
 	/** 스캔한 명함을 저장하고 해당 명함 상세 페이지로 이동하는 함수 */
 	const handleSaveCard = (qrCardId: number) => {
@@ -20,23 +18,23 @@ export default function QRScanView({ navigation }: any) {
 	};
 
 	/** 바코드 스캔 데이터 저장 함수 */
-	const handleBarcodeScan = React.useCallback(
-		({ data }: { data: string }) => {
-			// 스캔된 상태 업데이트
-			setScanned(true);
+	const handleBarcodeScan = ({ data }: { data: string }) => {
+		if (scannedRef.current) return;
+		scannedRef.current = true;
 
-			// 데이터 유효성 검사
-			if (!data.startsWith('scannect://')) {
-				Alert.alert('유효하지 않은 QR 코드입니다.');
-				setScanned(false);
-				return;
-			}
-
+		if (!data.startsWith('scannect://')) {
+			Alert.alert('유효하지 않은 QR 코드입니다.', 'SCANNECT 명함 QR코드를 인식해주세요!', [
+				{
+					text: '확인',
+					onPress: handleResetScan,
+				},
+			]);
+		} else {
 			// 링크 url에서 cardId 정보 get
 			const parsedURL = data.split('/');
 			const scannedCardId = parseInt(parsedURL[parsedURL.length - 1]);
 
-			console.log(scanned, scannedCardId);
+			console.log(scannedRef.current, scannedCardId);
 
 			Alert.alert(`명함 스캔 완료! id: ${scannedCardId}`, '스캔한 명함을 저장합니다...', [
 				{
@@ -45,9 +43,8 @@ export default function QRScanView({ navigation }: any) {
 				},
 				{ text: '취소', onPress: handleResetScan },
 			]);
-		},
-		[scanned]
-	);
+		}
+	};
 
 	useEffect(() => {
 		if (!permission) {
@@ -68,15 +65,13 @@ export default function QRScanView({ navigation }: any) {
 
 	return (
 		<View style={styles.container}>
-			{!scanned && (
-				<CameraView
-					style={styles.scanner}
-					onBarcodeScanned={handleBarcodeScan}
-					barcodeScannerSettings={{
-						barcodeTypes: ['qr'],
-					}}
-				/>
-			)}
+			<CameraView
+				style={styles.scanner}
+				onBarcodeScanned={handleBarcodeScan}
+				barcodeScannerSettings={{
+					barcodeTypes: ['qr'],
+				}}
+			/>
 		</View>
 	);
 }

--- a/src/screens/Exchange/QRScanView.tsx
+++ b/src/screens/Exchange/QRScanView.tsx
@@ -1,49 +1,16 @@
-import { Text, TouchableOpacity, View, StyleSheet, Alert } from 'react-native';
+import { Text, View, StyleSheet } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 
-export default function QRScanView({ navigation }: any) {
-	const scannedRef = useRef(false);
+import { useQRCode } from '../../hooks/useQRCode';
+import CommonButton from '../../components/CommonButton';
+
+export default function QRScanView() {
+	const { scanQR } = useQRCode();
 	const [permission, requestPermission] = useCameraPermissions();
 
-	/** 바코드 스캔 상태 초기화 함수 */
-	const handleResetScan = () => (scannedRef.current = false);
-
-	/** 스캔한 명함을 저장하고 해당 명함 상세 페이지로 이동하는 함수 */
-	const handleSaveCard = (qrCardId: number) => {
-		console.log(qrCardId, '저장 중...');
-		/* 명함 저장 */
-		/* 네비게이션 */
-		navigation.navigate('CardListTab', { screen: 'CardDetail', params: { cardId: qrCardId } });
-	};
-
-	/** 바코드 스캔 데이터 저장 함수 */
-	const handleBarcodeScan = ({ data }: { data: string }) => {
-		if (scannedRef.current) return;
-		scannedRef.current = true;
-
-		if (!data.startsWith('scannect://')) {
-			Alert.alert('유효하지 않은 QR 코드입니다.', 'SCANNECT 명함 QR코드를 인식해주세요!', [
-				{
-					text: '확인',
-					onPress: handleResetScan,
-				},
-			]);
-		} else {
-			// 링크 url에서 cardId 정보 get
-			const parsedURL = data.split('/');
-			const scannedCardId = parseInt(parsedURL[parsedURL.length - 1]);
-
-			console.log(scannedRef.current, scannedCardId);
-
-			Alert.alert(`명함 스캔 완료! id: ${scannedCardId}`, '스캔한 명함을 저장합니다...', [
-				{
-					text: '저장',
-					onPress: () => handleSaveCard(scannedCardId),
-				},
-				{ text: '취소', onPress: handleResetScan },
-			]);
-		}
+	const handleBarcodeScanned = ({ data }: { data: string }) => {
+		scanQR(data);
 	};
 
 	useEffect(() => {
@@ -56,9 +23,7 @@ export default function QRScanView({ navigation }: any) {
 		return (
 			<View style={styles.container}>
 				<Text>카메라 사용 권한이 필요합니다.</Text>
-				<TouchableOpacity onPress={requestPermission}>
-					<Text>권한 요청</Text>
-				</TouchableOpacity>
+				<CommonButton title="권한 요청" onPress={requestPermission} />
 			</View>
 		);
 	}
@@ -67,7 +32,7 @@ export default function QRScanView({ navigation }: any) {
 		<View style={styles.container}>
 			<CameraView
 				style={styles.scanner}
-				onBarcodeScanned={handleBarcodeScan}
+				onBarcodeScanned={handleBarcodeScanned}
 				barcodeScannerSettings={{
 					barcodeTypes: ['qr'],
 				}}

--- a/src/screens/Exchange/QRScanView.tsx
+++ b/src/screens/Exchange/QRScanView.tsx
@@ -1,9 +1,94 @@
-import { Text, View } from 'react-native';
+import { Text, TouchableOpacity, View, StyleSheet, Alert } from 'react-native';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import React, { useEffect, useState } from 'react';
 
-export default function QRScanView() {
+export default function QRScanView({ navigation }: any) {
+	const [scanned, setScanned] = useState(false);
+	const [permission, requestPermission] = useCameraPermissions();
+
+	/** 바코드 스캔 초기화 함수 */
+	const handleResetScan = () => {
+		setScanned(false);
+	};
+
+	/** 스캔한 명함을 저장하고 해당 명함 상세 페이지로 이동하는 함수 */
+	const handleSaveCard = (qrCardId: number) => {
+		console.log(qrCardId, '저장 중...');
+		/* 명함 저장 */
+		/* 네비게이션 */
+		navigation.navigate('CardListTab', { screen: 'CardDetail', params: { cardId: qrCardId } });
+	};
+
+	/** 바코드 스캔 데이터 저장 함수 */
+	const handleBarcodeScan = React.useCallback(
+		({ data }: { data: string }) => {
+			// 스캔된 상태 업데이트
+			setScanned(true);
+
+			// 데이터 유효성 검사
+			if (!data.startsWith('scannect://')) {
+				Alert.alert('유효하지 않은 QR 코드입니다.');
+				setScanned(false);
+				return;
+			}
+
+			// 링크 url에서 cardId 정보 get
+			const parsedURL = data.split('/');
+			const scannedCardId = parseInt(parsedURL[parsedURL.length - 1]);
+
+			console.log(scanned, scannedCardId);
+
+			Alert.alert(`명함 스캔 완료! id: ${scannedCardId}`, '스캔한 명함을 저장합니다...', [
+				{
+					text: '저장',
+					onPress: () => handleSaveCard(scannedCardId),
+				},
+				{ text: '취소', onPress: handleResetScan },
+			]);
+		},
+		[scanned]
+	);
+
+	useEffect(() => {
+		if (!permission) {
+			requestPermission();
+		}
+	}, []);
+
+	if (!permission?.granted) {
+		return (
+			<View style={styles.container}>
+				<Text>카메라 사용 권한이 필요합니다.</Text>
+				<TouchableOpacity onPress={requestPermission}>
+					<Text>권한 요청</Text>
+				</TouchableOpacity>
+			</View>
+		);
+	}
+
 	return (
-		<View>
-			<Text>스캐너어어</Text>
+		<View style={styles.container}>
+			{!scanned && (
+				<CameraView
+					style={styles.scanner}
+					onBarcodeScanned={handleBarcodeScan}
+					barcodeScannerSettings={{
+						barcodeTypes: ['qr'],
+					}}
+				/>
+			)}
 		</View>
 	);
 }
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	scanner: {
+		width: '100%',
+		height: '100%',
+	},
+});


### PR DESCRIPTION
## 📝 작업 내용

- `expo-camera` 라이브러리를 설치했습니다.
- QR 바코드 스캐너를 구현하고, 스캔 처리 로직을 useQRCode 훅에 추가했습니다.
- 스캔 처리 과정에서 간단한 데이터 유효성 검사를 진행하여 명함 QR이 아닌 다른 바코드를 인식하는 경우에 대한 예외처리를 작성했습니다.

## 🔍 참고 자료 (option)

- [Expo Camera](https://docs.expo.dev/versions/latest/sdk/camera/)

## 💬 기타 사항 (option)

- API 연결할 때 스캔한 명함을 저장하고, 중복 저장인 경우 예외 처리하는 코드를 추가할 예정입니다!

---
Closes #25 
