### PR TITLE
Feat [#34] 로그인, 회원가입 api 연결

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -28,7 +28,7 @@ export const useAuth = () => {
 				await setIsLoggedIn(true);
 				setLoginState(true);
 			} else {
-				console.log(res.message); // 또는 toast 등
+				console.log(res.message);
 			}
 		} catch (e) {
 			console.error(e);
@@ -62,7 +62,7 @@ export const useAuth = () => {
 		setName,
 		setId,
 		setPassword,
-		errors: useAuthStore.getState().errors, // 상태 그대로 전달
+		errors: useAuthStore.getState().errors,
 		handleSignUp,
 		handleLogin,
 	};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,69 @@
+import { login as postLogin, signUp as postSignUp } from '../server/auth';
+import { useAuthStore } from '../store/authStore';
+import { setIsLoggedIn } from '../utils/authStorage';
+
+export const useAuth = () => {
+	const {
+		name,
+		id,
+		password,
+		setName,
+		setId,
+		setPassword,
+		validateFields,
+		clearErrors,
+		setIsLoggedIn: setLoginState,
+	} = useAuthStore();
+
+	const handleSignUp = async () => {
+		clearErrors();
+		if (!validateFields('signup')) {
+			console.log('회원가입 유효성 실패');
+			return;
+		}
+
+		try {
+			const res = await postSignUp(name, id, password);
+			if (res.success) {
+				await setIsLoggedIn(true);
+				setLoginState(true);
+			} else {
+				console.log(res.message); // 또는 toast 등
+			}
+		} catch (e) {
+			console.error(e);
+		}
+	};
+
+	const handleLogin = async () => {
+		clearErrors();
+		if (!validateFields('login')) {
+			console.log('로그인 유효성 실패');
+			return;
+		}
+
+		try {
+			const res = await postLogin(id, password);
+			if (res.success) {
+				await setIsLoggedIn(true);
+				setLoginState(true);
+			} else {
+				console.log(res.message);
+			}
+		} catch (e) {
+			console.error(e);
+		}
+	};
+
+	return {
+		name,
+		id,
+		password,
+		setName,
+		setId,
+		setPassword,
+		errors: useAuthStore.getState().errors, // 상태 그대로 전달
+		handleSignUp,
+		handleLogin,
+	};
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,8 +1,13 @@
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { AuthStackParamList } from '../navigations/types';
 import { login as postLogin, signUp as postSignUp } from '../server/auth';
 import { useAuthStore } from '../store/authStore';
 import { setIsLoggedIn, setUserId } from '../utils/authStorage';
 
 export const useAuth = () => {
+	const navigation = useNavigation<NativeStackNavigationProp<AuthStackParamList>>();
+
 	const {
 		name,
 		id,
@@ -25,8 +30,7 @@ export const useAuth = () => {
 		try {
 			const res = await postSignUp(name, id, password);
 			if (res.success) {
-				await setIsLoggedIn(true);
-				setLoginState(true);
+				navigation.pop();
 			} else {
 				console.log(res.message);
 			}
@@ -46,8 +50,8 @@ export const useAuth = () => {
 			const res = await postLogin(id, password);
 			if (res.success) {
 				await setIsLoggedIn(true);
-				setLoginState(true);
 				await setUserId(res.data.id);
+				setLoginState(true);
 			} else {
 				console.log(res.message);
 			}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 import { login as postLogin, signUp as postSignUp } from '../server/auth';
 import { useAuthStore } from '../store/authStore';
-import { setIsLoggedIn } from '../utils/authStorage';
+import { setIsLoggedIn, setUserId } from '../utils/authStorage';
 
 export const useAuth = () => {
 	const {
@@ -47,6 +47,7 @@ export const useAuth = () => {
 			if (res.success) {
 				await setIsLoggedIn(true);
 				setLoginState(true);
+				await setUserId(res.data.id);
 			} else {
 				console.log(res.message);
 			}

--- a/src/screens/Auth/LoginView.tsx
+++ b/src/screens/Auth/LoginView.tsx
@@ -3,14 +3,15 @@ import CommonButton from '../../components/CommonButton';
 import typography from '../../styles/typography';
 import AuthTextInput from '../../components/auth/AuthTextInput';
 import spacing from '../../styles/spacing';
-import { useAuthStore } from '../../store/authStore';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { AuthStackParamList } from '../../navigations/types';
 import { useNavigation } from '@react-navigation/native';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function LoginView() {
-	const { id, password, setId, setPassword, errors, login } = useAuthStore();
+	const { id, password, setId, setPassword, errors, handleLogin } = useAuth();
 	const navigation = useNavigation<NativeStackNavigationProp<AuthStackParamList>>();
+
 	return (
 		<View style={styles.container}>
 			<Text style={[typography.h1, styles.title]}>Scannect</Text>
@@ -32,7 +33,7 @@ export default function LoginView() {
 			</View>
 
 			<View style={styles.buttonGroup}>
-				<CommonButton title="로그인" onPress={login} size="large" />
+				<CommonButton title="로그인" onPress={handleLogin} size="large" />
 				<CommonButton
 					title="회원가입"
 					onPress={() => navigation.navigate('회원가입')}

--- a/src/screens/Auth/SignUpView.tsx
+++ b/src/screens/Auth/SignUpView.tsx
@@ -3,10 +3,10 @@ import AuthTextInput from '../../components/auth/AuthTextInput';
 import CommonButton from '../../components/CommonButton';
 import spacing from '../../styles/spacing';
 import typography from '../../styles/typography';
-import { useAuthStore } from '../../store/authStore';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function SignUpView() {
-	const { name, id, password, setName, setId, setPassword, errors, signUp } = useAuthStore();
+	const { name, id, password, setName, setId, setPassword, errors, handleSignUp } = useAuth();
 
 	return (
 		<View style={styles.container}>
@@ -35,7 +35,7 @@ export default function SignUpView() {
 
 			<CommonButton
 				title="가입하기"
-				onPress={signUp}
+				onPress={handleSignUp}
 				size="large"
 				buttonStyle={{ marginBottom: spacing.xxxl }}
 			/>

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -3,14 +3,14 @@ import { httpClient } from './http';
 // 회원가입 API
 export const signUp = async (name: string, id: string, password: string) => {
 	try {
-		const { data } = await httpClient.post('/api/users', {
+		const { data } = await httpClient.post('/users', {
 			name,
 			id,
 			password,
 		});
 		return data;
 	} catch (error) {
-		// 에러 핸들링 필요시 여기에 추가
+		console.error('회원가입 실패:', error);
 		throw error;
 	}
 };
@@ -18,13 +18,13 @@ export const signUp = async (name: string, id: string, password: string) => {
 // 로그인 API
 export const login = async (id: string, password: string) => {
 	try {
-		const { data } = await httpClient.post('/api/users/login', {
+		const { data } = await httpClient.post('/users/login', {
 			id,
 			password,
 		});
 		return data;
 	} catch (error) {
-		// 에러 핸들링 필요시 여기에 추가
+		console.error('로그인 실패:', error);
 		throw error;
 	}
 };

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,30 @@
+import { httpClient } from './http';
+
+// 회원가입 API
+export const signUp = async (name: string, id: string, password: string) => {
+	try {
+		const { data } = await httpClient.post('/api/users', {
+			name,
+			id,
+			password,
+		});
+		return data;
+	} catch (error) {
+		// 에러 핸들링 필요시 여기에 추가
+		throw error;
+	}
+};
+
+// 로그인 API
+export const login = async (id: string, password: string) => {
+	try {
+		const { data } = await httpClient.post('/api/users/login', {
+			id,
+			password,
+		});
+		return data;
+	} catch (error) {
+		// 에러 핸들링 필요시 여기에 추가
+		throw error;
+	}
+};

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+const BASE_URL = 'https://scannect-be.onrender.com/api';
+const DEFAULT_TIMEOUT = 30000;
+
+export const createClient = () => {
+	const axiosInstance = axios.create({
+		baseURL: BASE_URL,
+		timeout: DEFAULT_TIMEOUT,
+		withCredentials: true,
+	});
+
+	return axiosInstance;
+};
+
+export const httpClient = createClient();

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { getIsLoggedIn, setIsLoggedIn } from '../utils/authStorage';
+import { getIsLoggedIn } from '../utils/authStorage';
 
 type AuthError = {
 	name?: string;
@@ -13,15 +13,15 @@ type AuthStore = {
 	password: string;
 	errors: AuthError;
 	isLoggedIn: boolean;
+
+	// 상태 제어 함수들
 	initLoginStatus: () => void;
 	setName: (value: string) => void;
 	setId: (value: string) => void;
 	setPassword: (value: string) => void;
-	validateFields: (type: 'login' | 'signup') => boolean;
+	setIsLoggedIn: (value: boolean) => void;
 	clearErrors: () => void;
-	signUp: () => void;
-	login: () => void;
-	logout: () => void;
+	validateFields: (type: 'login' | 'signup') => boolean;
 };
 
 export const useAuthStore = create<AuthStore>((set, get) => ({
@@ -39,6 +39,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 	setName: value => set({ name: value }),
 	setId: value => set({ id: value }),
 	setPassword: value => set({ password: value }),
+	setIsLoggedIn: value => set({ isLoggedIn: value }),
 
 	clearErrors: () => set({ errors: {} }),
 
@@ -54,32 +55,5 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 
 		set({ errors: newErrors });
 		return Object.keys(newErrors).length === 0;
-	},
-
-	signUp: async () => {
-		const { name, id, password, validateFields } = get();
-		if (validateFields('signup')) {
-			console.log('회원가입 요청:', { name, id, password });
-			await setIsLoggedIn(true);
-			set({ isLoggedIn: true });
-		} else {
-			console.log('회원가입 유효성 실패');
-		}
-	},
-
-	login: async () => {
-		const { id, password, validateFields } = get();
-		if (validateFields('login')) {
-			console.log('로그인 요청:', { id, password });
-			await setIsLoggedIn(true);
-			set({ isLoggedIn: true });
-		} else {
-			console.log('로그인 유효성 실패');
-		}
-	},
-
-	logout: async () => {
-		await setIsLoggedIn(false);
-		set({ isLoggedIn: false });
 	},
 }));

--- a/src/utils/authStorage.ts
+++ b/src/utils/authStorage.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const IS_LOGGED_IN_KEY = 'isLoggedIn';
+const USER_ID_KEY = 'userId';
 
 export const setIsLoggedIn = async (value: boolean) => {
 	try {
@@ -17,5 +18,30 @@ export const getIsLoggedIn = async (): Promise<boolean> => {
 	} catch (e) {
 		console.error('로그인 상태 불러오기 실패', e);
 		return false;
+	}
+};
+
+export const setUserId = async (userId: string) => {
+	try {
+		await AsyncStorage.setItem(USER_ID_KEY, userId);
+	} catch (e) {
+		console.error('유저 ID 저장 실패', e);
+	}
+};
+
+export const getUserId = async (): Promise<string | null> => {
+	try {
+		return await AsyncStorage.getItem(USER_ID_KEY);
+	} catch (e) {
+		console.error('유저 ID 불러오기 실패', e);
+		return null;
+	}
+};
+
+export const removeUserId = async () => {
+	try {
+		await AsyncStorage.removeItem(USER_ID_KEY);
+	} catch (e) {
+		console.error('유저 ID 삭제 실패', e);
 	}
 };


### PR DESCRIPTION
## 📝 작업 내용

### useAuth() 훅으로 비즈니스 로직 분리
- hook을 안쓰고, authStore에 상태 뿐만아니라 비즈니스 로직을 많이 들고 있는 구조에서 useAuth 훅으로 일부 책임을 이전하였습니다.

### http 파일 정의
- 기본적으로 공통적으로 쓰일 인스턴스를 적용하였습니다.

### auth 통신 파일 구현
- 서버 통신을 구현하였습니다.
- http 파일을 사용하여 auth와 같이 구현하면 될 것 같습니다.

### auth 응답 처리
- 로그인에 성공하면 로그인 상태를 변경하여 메인 스택으로 이동하게 됩니다. 그리고 로컬에 id 값을 저장하게 됩니다. 앞으로 id 값이 통신시 필요하시면 asyncStorage의 getUserId를 이용하여 로컬에 저장되어있는 아이디를 조회하시면 될 것 같습니다.
- 회원가입에 성공하게되면 로그인 화면으로 이동합니다.

## 💬 기타 사항 (option)

- http 파일을 통신시 이용한다는 점과, getUserId로 유저의 Id를 로컬에서 가져올 수 있다는 점 참고 바랍니다.
