### PR TITLE
Feat/#29 OCR 뷰 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,11 @@
 import RootNavigation from './src/navigations/RootNavigation';
+import Toast from 'react-native-toast-message';
 
 export default function App() {
-	return <RootNavigation />;
+	return (
+		<>
+			<RootNavigation />
+			<Toast />
+		</>
+	);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-native": "0.79.2",
         "react-native-element-dropdown": "^2.12.4",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-keyboard-aware-scroll-view": "^0.9.5",
         "react-native-qrcode-svg": "^6.3.15",
         "react-native-reanimated": "^3.17.3",
         "react-native-safe-area-context": "^5.3.0",
@@ -11026,6 +11027,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
@@ -11033,6 +11043,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-keyboard-aware-scroll-view": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz",
+      "integrity": "sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.2",
+        "react-native-iphone-x-helper": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.48.4"
       }
     },
     "node_modules/react-native-qrcode-svg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-native-safe-area-context": "^5.3.0",
         "react-native-screens": "^4.10.0",
         "react-native-svg": "^15.11.2",
+        "react-native-toast-message": "^2.3.0",
         "react-native-web": "^0.20.0",
         "zustand": "^5.0.3"
       },
@@ -11131,6 +11132,16 @@
         "css-tree": "^1.1.3",
         "warn-once": "0.1.1"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-toast-message": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.3.0.tgz",
+      "integrity": "sha512-d7LldTK1ei1Bl7RFhoOYw8hVQ4oKPQHORYI//xR9Pyz3HxSlFlvQbueE5X3KLoemRRgBrOUg3zY6DxXnxrVLRg==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native-safe-area-context": "^5.3.0",
     "react-native-screens": "^4.10.0",
     "react-native-svg": "^15.11.2",
+    "react-native-toast-message": "^2.3.0",
     "react-native-web": "^0.20.0",
     "zustand": "^5.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "@react-navigation/native-stack": "^7.3.9",
     "axios": "^1.8.4",
     "expo": "~53.0.8",
-    "expo-image-picker": "^16.1.4",
+    "expo-camera": "~16.1.6",
     "expo-file-system": "^18.1.10",
+    "expo-image-picker": "^16.1.4",
     "expo-location": "~18.1.4",
     "expo-sharing": "^13.1.5",
     "expo-status-bar": "~2.2.3",
@@ -27,14 +28,14 @@
     "react-native": "0.79.2",
     "react-native-element-dropdown": "^2.12.4",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-qrcode-svg": "^6.3.15",
     "react-native-reanimated": "^3.17.3",
     "react-native-safe-area-context": "^5.3.0",
     "react-native-screens": "^4.10.0",
     "react-native-svg": "^15.11.2",
     "react-native-web": "^0.20.0",
-    "zustand": "^5.0.3",
-    "expo-camera": "~16.1.6"
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/cardCreateUpdate/CardCreateForm.tsx
+++ b/src/components/cardCreateUpdate/CardCreateForm.tsx
@@ -83,7 +83,7 @@ export default function CardCreateForm({ onAnyInputFocus }: { onAnyInputFocus?: 
 				value={form.belongTo}
 				onChangeText={text => handleChange('belongTo', text)}
 				errorMessage={errors.belongTo}
-				placeholder="회사 이름을 입력하세요"
+				placeholder="소속 이름을 입력하세요"
 				onBlur={() => validateField('belongTo', form.belongTo)}
 			/>
 			<LabeledInput
@@ -118,7 +118,6 @@ export default function CardCreateForm({ onAnyInputFocus }: { onAnyInputFocus?: 
 				placeholder="01012345678 (- 제외)"
 				keyboardType="phone-pad"
 				onBlur={() => validateField('phoneNum', form.phoneNum)}
-				onFocus={onAnyInputFocus}
 			/>
 			<LabeledInput
 				label="유선전화"
@@ -126,7 +125,6 @@ export default function CardCreateForm({ onAnyInputFocus }: { onAnyInputFocus?: 
 				onChangeText={text => handleChange('companyTel', text)}
 				placeholder="02-1234-5678"
 				keyboardType="phone-pad"
-				onFocus={onAnyInputFocus}
 			/>
 			<LabeledInput
 				label="이메일"
@@ -137,7 +135,6 @@ export default function CardCreateForm({ onAnyInputFocus }: { onAnyInputFocus?: 
 				placeholder="example@domain.com"
 				keyboardType="email-address"
 				onBlur={() => validateField('email', form.email)}
-				onFocus={onAnyInputFocus}
 			/>
 			<LabeledInput
 				label="URL"
@@ -145,7 +142,6 @@ export default function CardCreateForm({ onAnyInputFocus }: { onAnyInputFocus?: 
 				onChangeText={text => handleChange('website', text)}
 				placeholder="https://"
 				keyboardType="url"
-				onFocus={onAnyInputFocus}
 			/>
 			<View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.s }}>
 				<CommonButton title="취소" onPress={() => {}} size="small" />

--- a/src/components/cardCreateUpdate/LabeledTextarea.tsx
+++ b/src/components/cardCreateUpdate/LabeledTextarea.tsx
@@ -10,6 +10,7 @@ interface Props {
 	placeholder?: string;
 	required?: boolean;
 	errorMessage?: string;
+	onFocus?: () => void;
 }
 
 export default function LabeledTextarea({

--- a/src/components/mypage/elements/Dropdown.tsx
+++ b/src/components/mypage/elements/Dropdown.tsx
@@ -9,7 +9,11 @@ import colors from '../../../styles/Colors';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import { useUiStore } from '../../../store/useUiStore';
 
-const DropdownMenu: React.FC = () => {
+type Props = {
+	showCreateOption?: boolean;
+};
+
+const DropdownMenu: React.FC<Props> = ({ showCreateOption = true }) => {
 	const { selectedCard, setSelectedCard } = useMypageStore();
 	const { cards } = useMypage();
 	const { dropdownOpen: open, setDropdownOpen: setOpen } = useUiStore();
@@ -21,9 +25,7 @@ const DropdownMenu: React.FC = () => {
 		}
 	}, [cards, selectedCard]);
 
-	const sortedCards = [...cards].sort((a, b) =>
-		a.isMain === b.isMain ? 0 : a.isMain ? -1 : 1
-	);
+	const sortedCards = [...cards].sort((a, b) => (a.isMain === b.isMain ? 0 : a.isMain ? -1 : 1));
 
 	const handleSelect = (card: Card | 'new') => {
 		setOpen(false);
@@ -61,10 +63,15 @@ const DropdownMenu: React.FC = () => {
 								</View>
 							</TouchableOpacity>
 						))}
-						<View style={styles.divider} />
-						<TouchableOpacity style={styles.dropdownItem} onPress={() => handleSelect('new')}>
-							<Text style={styles.createCardText}>+ 새로운 명함 생성</Text>
-						</TouchableOpacity>
+
+						{showCreateOption && (
+							<>
+								<View style={styles.divider} />
+								<TouchableOpacity style={styles.dropdownItem} onPress={() => handleSelect('new')}>
+									<Text style={styles.createCardText}>+ 새로운 명함 생성</Text>
+								</TouchableOpacity>
+							</>
+						)}
 					</View>
 				</>
 			)}

--- a/src/components/ocr/CardSave.tsx
+++ b/src/components/ocr/CardSave.tsx
@@ -1,0 +1,166 @@
+import { View, ScrollView, Alert } from 'react-native';
+import { CardForm, useCardForm } from '../../hooks/useCardForm';
+import LabeledInput from '../cardCreateUpdate/LabeledInput';
+import CommonButton from '../CommonButton';
+import LabeledTextarea from '../cardCreateUpdate/LabeledTextarea';
+import JobSelector from '../cardCreateUpdate/JobSelector';
+import Toast from 'react-native-toast-message';
+import { useNavigation } from '@react-navigation/native';
+
+interface Props {
+	initialData: Partial<CardForm>;
+}
+
+export default function CardSave({ initialData }: Props) {
+	const { form, errors, handleChange, validateField, resetForm } = useCardForm(initialData);
+	const navigation = useNavigation<any>();
+
+	const handleSave = () => {
+		let hasError = false;
+
+		const requiredFields: (keyof typeof form)[] = [
+			'name',
+			'belongTo',
+			'job',
+			'industry',
+			'position',
+			'email',
+			'phoneNum',
+		];
+
+		requiredFields.forEach(field => {
+			const value = form[field];
+			if (typeof value === 'string') {
+				const error = validateField(field, value);
+				if (error) {
+					hasError = true;
+				}
+			}
+		});
+
+		if (hasError) return;
+
+		Toast.show({
+			type: 'success',
+			text1: '명함이 성공적으로 저장되었습니다.',
+		});
+		resetForm();
+
+		navigation.navigate('명함 교환');
+	};
+
+	const handleCancel = () => {
+		Alert.alert(
+			'작성 취소',
+			'입력한 내용이 모두 삭제됩니다. 취소하시겠습니까?',
+			[
+				{
+					text: '아니요',
+					style: 'cancel',
+				},
+				{
+					text: '네',
+					style: 'destructive',
+					onPress: () => {
+						resetForm();
+						navigation.goBack();
+					},
+				},
+			],
+			{ cancelable: true }
+		);
+	};
+
+	return (
+		<ScrollView contentContainerStyle={{ padding: 16 }}>
+			<LabeledInput
+				label="이름"
+				required
+				value={form.name ?? ''}
+				onChangeText={text => handleChange('name', text)}
+				placeholder="이름을 입력하세요"
+				onBlur={() => validateField('name', form.name ?? '')}
+				errorMessage={errors.name}
+			/>
+			<LabeledInput
+				label="소속"
+				required
+				value={form.belongTo ?? ''}
+				onChangeText={text => handleChange('belongTo', text)}
+				onBlur={() => validateField('belongTo', form.belongTo ?? '')}
+				placeholder="소속 이름을 입력하세요"
+				errorMessage={errors.belongTo}
+			/>
+			<LabeledInput
+				label="직책"
+				required
+				value={form.job ?? ''}
+				onChangeText={text => handleChange('job', text)}
+				errorMessage={errors.job}
+				placeholder="직책을 입력하세요"
+				onBlur={() => validateField('job', form.job ?? '')}
+			/>
+			<LabeledInput
+				label="부서"
+				value={form.department ?? ''}
+				onChangeText={text => handleChange('department', text)}
+				placeholder="부서를 입력하세요"
+			/>
+			<JobSelector
+				industry={form.industry ?? ''}
+				position={form.position ?? ''}
+				onChangeIndustry={value => handleChange('industry', value)}
+				onChangePosition={value => handleChange('position', value)}
+				industryError={errors.industry}
+				positionError={errors.position}
+			/>
+			<LabeledInput
+				label="휴대폰"
+				required
+				value={form.phoneNum ?? ''}
+				onChangeText={text => handleChange('phoneNum', text)}
+				placeholder="01012345678 (- 제외)"
+				keyboardType="phone-pad"
+				onBlur={() => validateField('phoneNum', form.phoneNum ?? '')}
+				errorMessage={errors.phoneNum}
+			/>
+			<LabeledInput
+				label="유선전화"
+				value={form.companyTel ?? ''}
+				onChangeText={text => handleChange('companyTel', text)}
+				placeholder="02-1234-5678"
+				keyboardType="phone-pad"
+			/>
+			<LabeledInput
+				label="이메일"
+				required
+				value={form.email ?? ''}
+				onChangeText={text => handleChange('email', text)}
+				onBlur={() => validateField('email', form.email ?? '')}
+				placeholder="example@domain.com"
+				errorMessage={errors.email}
+				keyboardType="email-address"
+				autoCapitalize="none"
+			/>
+			<LabeledInput
+				label="URL"
+				value={form.website}
+				onChangeText={text => handleChange('website', text)}
+				placeholder="https://"
+				keyboardType="url"
+			/>
+			<LabeledTextarea
+				label="메모"
+				value={form.content ?? ''}
+				onChangeText={text => handleChange('content', text)}
+				placeholder="상대방에 대한 메모를 입력하세요"
+				errorMessage={errors.content}
+			/>
+
+			<View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 24 }}>
+				<CommonButton title="취소" onPress={handleCancel} size="small" />
+				<CommonButton title="명함 저장" onPress={handleSave} size="small" />
+			</View>
+		</ScrollView>
+	);
+}

--- a/src/components/ocr/CardSave.tsx
+++ b/src/components/ocr/CardSave.tsx
@@ -43,6 +43,7 @@ export default function CardSave({ initialData }: Props) {
 		Toast.show({
 			type: 'success',
 			text1: '명함이 성공적으로 저장되었습니다.',
+			position: 'bottom'
 		});
 		resetForm();
 

--- a/src/components/ocr/LoadingOverlay.tsx
+++ b/src/components/ocr/LoadingOverlay.tsx
@@ -1,0 +1,33 @@
+import { ActivityIndicator, StyleSheet, View, Text } from 'react-native';
+import colors from '../../styles/Colors';
+
+const LoadingOverlay = () => {
+	return (
+		<View style={styles.overlay}>
+			<ActivityIndicator size="large" color={colors.primary} />
+			<Text style={styles.text}>명함 정보를 추출 중입니다...</Text>
+		</View>
+	);
+};
+
+export default LoadingOverlay;
+
+const styles = StyleSheet.create({
+	overlay: {
+		position: 'absolute',
+		top: 0,
+		left: 0,
+		width: '100%',
+		height: '100%',
+		backgroundColor: 'rgba(0, 0, 0, 0.3)',
+		justifyContent: 'center',
+		alignItems: 'center',
+		zIndex: 999,
+	},
+	text: {
+		marginTop: 12,
+		color: 'white',
+		fontSize: 16,
+		fontWeight: '600',
+	},
+});

--- a/src/components/ocr/OCRImageSourceModal.tsx
+++ b/src/components/ocr/OCRImageSourceModal.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Modal, Pressable, View, StyleSheet, Text } from 'react-native';
+import CommonButton from '../CommonButton';
+import spacing from '../../styles/spacing';
+import colors from '../../styles/Colors';
+import typography from '../../styles/typography';
+import { pickImage } from '../../utils/pickImage';
+import { takePhoto } from '../../utils/takePhoto';
+
+interface Props {
+	visible: boolean;
+	onClose: () => void;
+	onSelect: (source: 'camera' | 'gallery', imageUri?: string) => void;
+}
+
+export default function OCRImageSourceModal({ visible, onClose, onSelect }: Props) {
+	const handleGallery = async () => {
+		const uri = await pickImage();
+		if (uri) {
+			onSelect('gallery', uri);
+			onClose();
+		}
+	};
+
+	const handleCamera = async () => {
+		const uri = await takePhoto();
+		if (uri) {
+			onSelect('camera', uri);
+			onClose();
+		}
+	};
+
+	return (
+		<Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+			<Pressable style={styles.backdrop} onPress={onClose}>
+				<View style={styles.modalContent}>
+					<Text style={[typography.bodyBold, styles.title]}>
+						종이명함을 가져올 방법을 선택하세요
+					</Text>
+					<CommonButton
+						title="카메라 촬영"
+						onPress={handleCamera}
+						size="medium"
+						buttonStyle={{ marginBottom: spacing.s }}
+					/>
+					<CommonButton title="앨범 선택" onPress={handleGallery} size="medium" />
+				</View>
+			</Pressable>
+		</Modal>
+	);
+}
+
+const styles = StyleSheet.create({
+	backdrop: {
+		flex: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+		backgroundColor: 'rgba(0, 0, 0, 0.3)',
+	},
+	modalContent: {
+		width: 300,
+		backgroundColor: colors.grayscaleGray1,
+		borderRadius: 12,
+		padding: spacing.l,
+		alignItems: 'center',
+	},
+	title: {
+		marginBottom: spacing.l,
+	},
+});

--- a/src/hooks/useOCR.ts
+++ b/src/hooks/useOCR.ts
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { postOCR, getOCR } from '../server/ocr';
+
+export const useOCR = () => {
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<Error | null>(null);
+	const [result, setResult] = useState<any>(null);
+
+	const requestOCR = async (imageUri: string) => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const data = await postOCR(imageUri);
+			setResult(data);
+			return data;
+		} catch (err: any) {
+			setError(err);
+			throw err;
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const fetchOCR = async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const data = await getOCR();
+			setResult(data);
+			return data;
+		} catch (err: any) {
+			setError(err);
+			throw err;
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return {
+		result,
+		loading,
+		error,
+		requestOCR,
+		fetchOCR,
+	};
+};

--- a/src/hooks/useOCR.ts
+++ b/src/hooks/useOCR.ts
@@ -31,8 +31,8 @@ export const useOCR = () => {
 				setTimeout(() => {
 					resolve({
 						name: '홍길동',
-						company: '오픈AI 주식회사',
-						phone: '010-1234-5678',
+						belongTo: '오픈AI 주식회사',
+						phoneNum: '01012345678',
 						email: 'honggildong@example.com',
 					});
 				}, 5000)

--- a/src/hooks/useOCR.ts
+++ b/src/hooks/useOCR.ts
@@ -6,14 +6,40 @@ export const useOCR = () => {
 	const [error, setError] = useState<Error | null>(null);
 	const [result, setResult] = useState<any>(null);
 
+	// const requestOCR = async (imageUri: string) => {
+	// 	setLoading(true);
+	// 	setError(null);
+
+	// 	try {
+	// 		const data = await postOCR(imageUri);
+	// 		setResult(data);
+	// 		return data;
+	// 	} catch (err: any) {
+	// 		setError(err);
+	// 		throw err;
+	// 	} finally {
+	// 		setLoading(false);
+	// 	}
+	// };
+
 	const requestOCR = async (imageUri: string) => {
 		setLoading(true);
 		setError(null);
 
 		try {
-			const data = await postOCR(imageUri);
-			setResult(data);
-			return data;
+			const dummyResult = await new Promise(resolve =>
+				setTimeout(() => {
+					resolve({
+						name: '홍길동',
+						company: '오픈AI 주식회사',
+						phone: '010-1234-5678',
+						email: 'honggildong@example.com',
+					});
+				}, 5000)
+			);
+
+			setResult(dummyResult);
+			return dummyResult;
 		} catch (err: any) {
 			setError(err);
 			throw err;

--- a/src/hooks/useOCR.ts
+++ b/src/hooks/useOCR.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { postOCR, getOCR } from '../server/ocr';
+import { postOCR } from '../server/ocr';
 
 export const useOCR = () => {
 	const [loading, setLoading] = useState(false);
@@ -22,27 +22,10 @@ export const useOCR = () => {
 		}
 	};
 
-	const fetchOCR = async () => {
-		setLoading(true);
-		setError(null);
-
-		try {
-			const data = await getOCR();
-			setResult(data);
-			return data;
-		} catch (err: any) {
-			setError(err);
-			throw err;
-		} finally {
-			setLoading(false);
-		}
-	};
-
 	return {
 		result,
 		loading,
 		error,
 		requestOCR,
-		fetchOCR,
 	};
 };

--- a/src/navigations/ExchangeStack.tsx
+++ b/src/navigations/ExchangeStack.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import GPSView from '../screens/Exchange/GPSView';
 import QRGenerationView from '../screens/Exchange/QRGenerationView';
 import QRScanView from '../screens/Exchange/QRScanView';
+import OCRView from '../screens/Exchange/OCRView';
 
 const Stack = createNativeStackNavigator();
 
@@ -16,7 +17,7 @@ export default function ExchangeStack() {
 				options={{ title: 'QR 코드 생성' }}
 			/>
 			<Stack.Screen name="QRScan" component={QRScanView} options={{ title: 'QR 코드 스캔' }} />
-			<Stack.Screen name="PaperScan" component={QRGenerationView} options={{ title: 'OCR 교환' }} />
+			<Stack.Screen name="PaperScan" component={OCRView} options={{ title: 'OCR 교환' }} />
 		</Stack.Navigator>
 	);
 }

--- a/src/screens/Exchange/GPSView.tsx
+++ b/src/screens/Exchange/GPSView.tsx
@@ -1,26 +1,29 @@
 /* eslint-disable prettier/prettier */
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import CommonButton from '../../components/CommonButton';
-import commonStyles from '../../styles/commonStyles';
 import ScreenContainer from '../../components/ScreenContainer';
 import GPSSwitch from '../../components/gps/GPSSwitch';
 import GPSSectionList from '../../components/gps/GPSList';
 import { useGPSStore } from '../../store/gpsStore';
-import { useEffect, useState } from 'react';
-import { dummyData } from '../../model/gpsUser';
+import { useState } from 'react';
 import spacing from '../../styles/spacing';
 import GPSOffView from '../../components/gps/GPSOffView';
 import ExchangeBottomSheet from '../../components/gps/ExchangeBottomSheet';
 import DropdownMenu from '../../components/mypage/elements/Dropdown';
+import OCRImageSourceModal from '../../components/ocr/OCRImageSourceModal';
 
 export default function GPSView({ navigation }: any) {
 	const { gpsUserList, selectedUserIds, setGPSUserList, isLocationOn } = useGPSStore();
 	const [isBottomSheetVisible, setBottomSheetVisible] = useState(false);
+	const [isImageSourceModalVisible, setImageSourceModalVisible] = useState(false);
 
 	const handleExchangeOption = (type: 'QRGenerate' | 'QRScan' | 'PaperScan') => {
-		//console.log('클릭한 뷰로 이동 :', type);
-		navigation.navigate(type);
 		setBottomSheetVisible(false);
+		if (type === 'PaperScan') {
+			setImageSourceModalVisible(true);
+		} else {
+			navigation.navigate(type);
+		}
 	};
 
 	return (
@@ -52,6 +55,14 @@ export default function GPSView({ navigation }: any) {
 				onSelect={type => {
 					handleExchangeOption(type);
 					setBottomSheetVisible(false);
+				}}
+			/>
+			<OCRImageSourceModal
+				visible={isImageSourceModalVisible}
+				onClose={() => setImageSourceModalVisible(false)}
+				onSelect={(source, imageUri) => {
+					setImageSourceModalVisible(false);
+					navigation.navigate('PaperScan', { source, imageUri });
 				}}
 			/>
 		</ScreenContainer>

--- a/src/screens/Exchange/GPSView.tsx
+++ b/src/screens/Exchange/GPSView.tsx
@@ -27,7 +27,7 @@ export default function GPSView({ navigation }: any) {
 		<ScreenContainer>
 			<View style={styles.header}>
 				<View style={styles.headerText}>
-					<DropdownMenu />
+					<DropdownMenu showCreateOption={false} />
 				</View>
 				<GPSSwitch></GPSSwitch>
 			</View>

--- a/src/screens/Exchange/OCRView.tsx
+++ b/src/screens/Exchange/OCRView.tsx
@@ -1,10 +1,11 @@
 import { useRoute } from '@react-navigation/native';
-import { View } from 'react-native';
 import ScreenContainer from '../../components/ScreenContainer';
 import CardSave from '../../components/ocr/CardSave';
 import LoadingOverlay from '../../components/ocr/LoadingOverlay';
 import { useOCR } from '../../hooks/useOCR';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 export default function OCRView() {
 	const route = useRoute<any>();
@@ -21,8 +22,16 @@ export default function OCRView() {
 		<>
 			{loading && <LoadingOverlay />}
 			<ScreenContainer>
-				<View style={{ flex: 1 }}>{result && <CardSave initialData={result} />}</View>
+				<KeyboardAwareScrollView
+					contentContainerStyle={{ flexGrow: 1 }}
+					enableOnAndroid
+					keyboardShouldPersistTaps="handled"
+					showsVerticalScrollIndicator={false}
+					extraScrollHeight={100}
+				>
+					{result && <CardSave initialData={result} />}
+				</KeyboardAwareScrollView>
 			</ScreenContainer>
 		</>
 	);
-};
+}

--- a/src/screens/Exchange/OCRView.tsx
+++ b/src/screens/Exchange/OCRView.tsx
@@ -1,0 +1,28 @@
+import { useRoute } from '@react-navigation/native';
+import { View } from 'react-native';
+import ScreenContainer from '../../components/ScreenContainer';
+import CardSave from '../../components/ocr/CardSave';
+import LoadingOverlay from '../../components/ocr/LoadingOverlay';
+import { useOCR } from '../../hooks/useOCR';
+import { useEffect } from 'react';
+
+export default function OCRView() {
+	const route = useRoute<any>();
+	const { imageUri } = route.params ?? {};
+	const { loading, result, requestOCR } = useOCR();
+
+	useEffect(() => {
+		if (imageUri) {
+			requestOCR(imageUri);
+		}
+	}, [imageUri]);
+
+	return (
+		<>
+			{loading && <LoadingOverlay />}
+			<ScreenContainer>
+				<View style={{ flex: 1 }}>{result && <CardSave initialData={result} />}</View>
+			</ScreenContainer>
+		</>
+	);
+};

--- a/src/screens/Exchange/OCRView.tsx
+++ b/src/screens/Exchange/OCRView.tsx
@@ -3,8 +3,7 @@ import ScreenContainer from '../../components/ScreenContainer';
 import CardSave from '../../components/ocr/CardSave';
 import LoadingOverlay from '../../components/ocr/LoadingOverlay';
 import { useOCR } from '../../hooks/useOCR';
-import { useEffect, useRef } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
+import { useEffect } from 'react';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 export default function OCRView() {

--- a/src/screens/MyPage/CardCreateView.tsx
+++ b/src/screens/MyPage/CardCreateView.tsx
@@ -1,33 +1,19 @@
-import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
-import { useRef } from 'react';
 import ScreenContainer from '../../components/ScreenContainer';
 import CardCreateForm from '../../components/cardCreateUpdate/CardCreateForm';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 export default function CardCreateView() {
-	const scrollRef = useRef<ScrollView>(null);
-
-	const onFocus = () => {
-		setTimeout(() => {
-			scrollRef.current?.scrollToEnd({ animated: true });
-		}, 300);
-	};
-
 	return (
 		<ScreenContainer>
-			<KeyboardAvoidingView
-				behavior={Platform.select({ ios: 'padding', android: undefined })}
-				keyboardVerticalOffset={80}
-				style={{ flex: 1 }}
+			<KeyboardAwareScrollView
+				contentContainerStyle={{ flexGrow: 1 }}
+				keyboardShouldPersistTaps="handled"
+				showsVerticalScrollIndicator={false}
+				enableOnAndroid
+				extraScrollHeight={100}
 			>
-				<ScrollView
-					ref={scrollRef}
-					contentContainerStyle={{ flexGrow: 1 }}
-					keyboardShouldPersistTaps="handled"
-					showsVerticalScrollIndicator={false}
-				>
-					<CardCreateForm onAnyInputFocus={onFocus} />
-				</ScrollView>
-			</KeyboardAvoidingView>
+				<CardCreateForm />
+			</KeyboardAwareScrollView>
 		</ScreenContainer>
 	);
 }

--- a/src/server/ocr.ts
+++ b/src/server/ocr.ts
@@ -22,13 +22,3 @@ export const postOCR = async (imageUri: string) => {
     }
 };
 
-export const getOCR = async () => {
-    try {
-        const { data } = await httpClient.post('');
-        return data;
-    } catch (error) {
-        console.error('OCR GET 실패:', error);
-        throw error;
-    }
-};
-

--- a/src/server/ocr.ts
+++ b/src/server/ocr.ts
@@ -1,0 +1,34 @@
+import { httpClient } from './http';
+
+export const postOCR = async (imageUri: string) => {
+    try {
+        const formData = new FormData();
+        formData.append('image', {
+            uri: imageUri,
+            name: 'photo.jpg',
+            type: 'image/jpeg',
+        } as any);
+
+        const { data } = await httpClient.post('', formData, {
+            headers: {
+                'Content-Type': 'multipart/form-data',
+            },
+        });
+
+        return data;
+    } catch (error) {
+        console.error('OCR POST 실패:', error);
+        throw error;
+    }
+};
+
+export const getOCR = async () => {
+    try {
+        const { data } = await httpClient.post('');
+        return data;
+    } catch (error) {
+        console.error('OCR GET 실패:', error);
+        throw error;
+    }
+};
+

--- a/src/utils/pickImage.tsx
+++ b/src/utils/pickImage.tsx
@@ -1,0 +1,24 @@
+import * as ImagePicker from 'expo-image-picker';
+import { Alert } from 'react-native';
+
+export const pickImage = async (): Promise<string | null> => {
+	const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+	if (!permissionResult.granted) {
+		Alert.alert('권한이 필요합니다', '갤러리 접근 권한을 허용해주세요.');
+		return null;
+	}
+
+	const result = await ImagePicker.launchImageLibraryAsync({
+		allowsEditing: true,
+		aspect: [4, 3] as [number, number],
+		quality: 0.7,
+		base64: false,
+	});
+
+	if (result.canceled || result.assets.length === 0) {
+		return null;
+	}
+
+	return result.assets[0].uri;
+};

--- a/src/utils/takePhoto.ts
+++ b/src/utils/takePhoto.ts
@@ -1,0 +1,24 @@
+import { Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+
+export const takePhoto = async (): Promise<string | null> => {
+	const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
+
+	if (!permissionResult.granted) {
+		Alert.alert('권한이 필요합니다', '카메라 접근 권한을 허용해주세요.');
+		return null;
+	}
+
+	const result = await ImagePicker.launchCameraAsync({
+		allowsEditing: true,
+		aspect: [4, 3],
+		quality: 0.7,
+		base64: false,
+	});
+
+	if (result.canceled || result.assets.length === 0) {
+		return null;
+	}
+
+	return result.assets[0].uri;
+};


### PR DESCRIPTION
## 📝 작업 내용
- GPS 교환에서 드롭다운을 통해 명함을 고를 때 [새로운 명함 생성] 항목이 보이지 않게 하였습니다.
- [종이 명함 스캔]을 누르면 [카메라 촬영], [앨범 선택]을 할 수 있는 모달이 표시됩니다.
- API 함수와 훅은 임시 로직만 작성해둔 상태이고, 이미지를 업로드하면 5초 후에 저장폼으로 넘어가게 됩니다.
- 내 명함 생성에서 사용한 입력폼과 유효성 로직을 재사용하였습니다.
- 입력 시 키보드가 화면을 가리는 것을 방지하기 위해 `react-native-keyboard-aware-scroll-view`를 설치하였습니다.
- OCR 명함 저장 성공 시, 화면 하단에 토스트가 표시되게 됩니다. 이를 위해 `react-native-toast-message`를 설치하였습니다.

## 💬 기타 사항 (option)
- 추후 타유저 명함 저장 API 로직을 사용할 예정입니다.
- 특정 작업이 완료된 후 간단한 안내를 위해 `react-native-toast-message`를 다른 곳에서도 사용하시면 좋을 것 같습니다!