### PR TITLE
Feat/#44 명함 검색 API 연동

### DIFF
--- a/src/components/cardList/SearchListView.tsx
+++ b/src/components/cardList/SearchListView.tsx
@@ -1,0 +1,34 @@
+import { Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+
+import commonStyles from '../../styles/commonStyles';
+import { useCardStore } from '../../store/cardStore';
+import CardItem from './sectionListView/CardItem';
+import spacing from '../../styles/spacing';
+
+export default function SearchListView() {
+	const { searchList, setIsSearching } = useCardStore();
+	return (
+		<ScrollView contentContainerStyle={styles.container}>
+			{searchList.length === 0 ? (
+				<Text style={[commonStyles.bodyText, styles.noResultText]}>검색 결과가 없습니다.</Text>
+			) : (
+				searchList.map(card => <CardItem key={card.id} {...card} />)
+			)}
+			<Pressable style={{ marginTop: spacing.l }} onPress={() => setIsSearching(false)}>
+				<Text style={commonStyles.captionText}>홈으로 돌아가기</Text>
+			</Pressable>
+		</ScrollView>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		alignItems: 'center',
+		paddingTop: spacing.m,
+	},
+	noResultText: {
+		marginTop: spacing.xxxl,
+		marginBottom: spacing.m,
+	},
+});

--- a/src/components/cardList/elements/HeartIcon.tsx
+++ b/src/components/cardList/elements/HeartIcon.tsx
@@ -33,6 +33,6 @@ export default function HeartIcon({ id, favorite, size = 30 }: IHeartProp) {
 
 const styles = StyleSheet.create({
 	heartButton: {
-		paddingRight: spacing.xs,
+		marginRight: spacing.sm,
 	},
 });

--- a/src/components/cardList/elements/SearchInput.tsx
+++ b/src/components/cardList/elements/SearchInput.tsx
@@ -1,14 +1,24 @@
-import { Alert, Pressable, TextInput, StyleSheet } from 'react-native';
-import { useRef, useState } from 'react';
+import { Pressable, TextInput, StyleSheet } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
 import Fontisto from '@expo/vector-icons/Fontisto';
 
-import colors from '../../styles/Colors';
-import spacing from '../../styles/spacing';
+import colors from '../../../styles/Colors';
+import spacing from '../../../styles/spacing';
+import { useCardList } from '../../../hooks/useCardList';
+import { useCardStore } from '../../../store/cardStore';
 
 export default function SearchInput() {
 	const inputRef = useRef<TextInput>(null);
+	const { handleSearchCards } = useCardList();
+	const isSearching = useCardStore(state => state.isSearching);
+
 	const [keyword, setKeyword] = useState('');
-	const onChangeKeyword = (payload: string) => setKeyword(payload);
+	const handleChange = (payload: string) => setKeyword(payload);
+
+	useEffect(() => {
+		if (!isSearching) setKeyword('');
+	}, [isSearching]);
+
 	return (
 		<Pressable
 			style={styles.inputContainer}
@@ -21,10 +31,8 @@ export default function SearchInput() {
 				ref={inputRef}
 				placeholder="키워드를 입력해주세요..."
 				value={keyword}
-				onChangeText={onChangeKeyword}
-				onSubmitEditing={() =>
-					Alert.alert(!keyword ? '검색할 키워드를 입력해주세요.' : `키워드: ${keyword}`)
-				}
+				onChangeText={handleChange}
+				onSubmitEditing={() => handleSearchCards(keyword)}
 				keyboardType="default"
 				returnKeyType="search"
 				style={styles.searchInput}

--- a/src/components/cardList/sectionListView/CardItem.tsx
+++ b/src/components/cardList/sectionListView/CardItem.tsx
@@ -30,11 +30,11 @@ export default function CardItem(props: ICardItem) {
 			]}
 		>
 			<HeartIcon id={props.id} favorite={props.favorite} />
-			<View style={{ width: '75%' }}>
+			<View style={{ width: '80%' }}>
 				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
 					<Text style={styles.cardItemName}>{props.nickname}</Text>
 					<Text style={{ ...styles.cardItemSubInfo, marginLeft: 7 }}>
-						{props.belongTo} | {props.department} / {props.position}
+						{props.belongTo} | {props.job}
 					</Text>
 				</View>
 				{props.memo ? (

--- a/src/hooks/useCardList.ts
+++ b/src/hooks/useCardList.ts
@@ -4,13 +4,14 @@ import {
 	updateFavorite,
 	deleteCard,
 	updateMemo,
+	searchCards,
 } from '../server/cardList';
 import { useCardStore } from '../store/cardStore';
 import { getUserId } from '../utils/authStorage';
 
 /** 타유저 명함 관련 비즈니스 로직 hook */
 export const useCardList = () => {
-	const { cardList, setCardList, setIsLoading } = useCardStore();
+	const { cardList, setCardList, setSearchList, setIsLoading, setIsSearching } = useCardStore();
 	const handleFetchCards = async (loading: boolean) => {
 		try {
 			const userId = await getUserId(); // id: tester, password: 123456
@@ -61,5 +62,23 @@ export const useCardList = () => {
 		}
 	};
 
-	return { handleFetchCards, handleEditCard, handleDeleteCard };
+	const handleSearchCards = async (keyword: string) => {
+		try {
+			const userId = await getUserId(); // id: tester, password: 123456
+			if (!userId) throw new Error('로그인 정보 없음');
+
+			setIsLoading(true);
+			const cards = await searchCards(userId, keyword);
+			setSearchList(cards);
+			setIsSearching(true);
+			return cards;
+		} catch (e) {
+			console.error('명함 검색 실패', e);
+			return false;
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return { handleFetchCards, handleEditCard, handleDeleteCard, handleSearchCards };
 };

--- a/src/screens/CardList/CardListView.tsx
+++ b/src/screens/CardList/CardListView.tsx
@@ -12,11 +12,12 @@ import { useEffect } from 'react';
 import commonStyles from '../../styles/commonStyles';
 import colors from '../../styles/Colors';
 import ScreenContainer from '../../components/ScreenContainer';
-import SearchInput from '../../components/cardList/SearchInput';
+import SearchInput from '../../components/cardList/elements/SearchInput';
 import SortOption from '../../components/cardList/elements/SortOption';
 import CardSectionList from '../../components/cardList/sectionListView/SectionList';
 import CardBottomSheet from '../../components/cardList/CardBottomSheet';
 import EmptyListView from '../../components/cardList/EmptyListView';
+import SearchListView from '../../components/cardList/SearchListView';
 import { useCardStore } from '../../store/cardStore';
 import { useCardList } from '../../hooks/useCardList';
 
@@ -25,8 +26,16 @@ if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental
 	UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 
+function LoadingView() {
+	return (
+		<View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+			<ActivityIndicator size="large" />
+		</View>
+	);
+}
+
 export default function CardListView({ navigation }: any) {
-	const { cardList, isLoading } = useCardStore();
+	const { cardList, searchList, isLoading, isSearching } = useCardStore();
 	const { handleFetchCards } = useCardList();
 
 	useEffect(() => {
@@ -37,24 +46,27 @@ export default function CardListView({ navigation }: any) {
 		load();
 	}, []);
 
-	if (isLoading) {
-		return (
-			<View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-				<ActivityIndicator size="large" />
-			</View>
-		);
-	}
-
 	return (
 		<ScreenContainer>
 			<View style={{ height: '100%' }}>
 				<Text style={styles.headerTitle}>명함 리스트</Text>
 				<SearchInput />
+
 				<View style={styles.mainLabelWrapper}>
-					<Text style={styles.mainLabel}>전체 명함 ({cardList.length})</Text>
-					<SortOption />
+					<Text style={styles.mainLabel}>
+						{isSearching ? `검색 결과 (${searchList.length})` : `전체 명함 (${cardList.length})`}
+					</Text>
+					{!isSearching && <SortOption />}
 				</View>
-				{cardList.length === 0 ? <EmptyListView navigation={navigation} /> : <CardSectionList />}
+				{isLoading ? (
+					<LoadingView />
+				) : cardList.length === 0 ? (
+					<EmptyListView navigation={navigation} />
+				) : isSearching ? (
+					<SearchListView />
+				) : (
+					<CardSectionList />
+				)}
 			</View>
 			<CardBottomSheet />
 		</ScreenContainer>

--- a/src/server/cardList.ts
+++ b/src/server/cardList.ts
@@ -25,3 +25,9 @@ export const updateMemo = async (tableId: number, memo: string) => {
 export const deleteCard = async (tableId: number) => {
 	await httpClient.delete(`/card-list/${tableId}`);
 };
+
+/** 타유저 명함 검색 API */
+export const searchCards = async (userId: string, keyword: string) => {
+	const { data } = await httpClient.get(`/card-list/user/${userId}/search?keyword=${keyword}`);
+	return data.data;
+};

--- a/src/store/cardStore.ts
+++ b/src/store/cardStore.ts
@@ -8,12 +8,16 @@ type CardStore = {
 		commonCards: ICardItem[];
 		hiddenCards: ICardItem[];
 	};
+	searchList: ICardItem[];
+	isSearching: boolean;
 	sortOption: 'latest' | 'name';
 	isLoading: boolean;
 	setCardList: (cards: ICardItem[]) => void;
+	setSearchList: (cards: ICardItem[]) => void;
 	filterCardList: () => void;
 	sortCardList: (option: 'latest' | 'name') => void;
 	setIsLoading: (loading: boolean) => void;
+	setIsSearching: (searching: boolean) => void;
 };
 
 export const useCardStore = create<CardStore>((set, get) => ({
@@ -23,8 +27,10 @@ export const useCardStore = create<CardStore>((set, get) => ({
 		commonCards: [],
 		hiddenCards: [],
 	},
+	searchList: [],
 	sortOption: 'latest', // 정렬 기준
 	isLoading: false,
+	isSearching: false,
 	setCardList: cards => {
 		set({ cardList: cards });
 		get().filterCardList();
@@ -43,5 +49,9 @@ export const useCardStore = create<CardStore>((set, get) => ({
 		else tempList.sort((a, b) => (a.nickname.toLowerCase() < b.nickname.toLowerCase() ? -1 : 1));
 		get().setCardList(tempList);
 	},
+	setSearchList: cards => {
+		set({ searchList: cards });
+	},
 	setIsLoading: loading => set({ isLoading: loading }),
+	setIsSearching: searching => set({ isSearching: searching }),
 }));


### PR DESCRIPTION
## 📝 작업 내용

- 명함 키워드 검색 API를 연동했습니다.
- 검색 결과를 렌더링하는 `SearchListView`를 구현하여 `isSearching === true`일 때 렌더링되도록 처리했습니다.
- 검색 결과 하단의 "홈으로 돌아가기"를 클릭하면 전체 명함 리스트 화면으로 되돌아가게 됩니다.

## 💬 기타 사항 (option)

- 현재 검색 결과에서 모달 열기 및 상세 페이지 네비게이션이 작동하지 않습니다. 백에서 검색 API 수정이 완료되면 정상 작동할 것으로 보이는데, 이건 API 수정 후에 다시 테스트해보겠습니다! 이외 동작에는 문제 없습니다

---
Closes #44 