### PR TITLE
Feat/#45 QR 교환 API 연동

### DIFF
--- a/src/hooks/useQRCode.ts
+++ b/src/hooks/useQRCode.ts
@@ -1,20 +1,18 @@
-import { useNavigation } from '@react-navigation/native';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import { useRef } from 'react';
-import { Alert } from 'react-native';
 
-import { saveQRCard } from '../server/qrcode';
+import { saveCard } from '../server/qrcode';
 import { getUserId } from '../utils/authStorage';
+import { useCardList } from './useCardList';
 
 export function useQRCode() {
 	const qrRef = useRef<any>(null);
 	const scannedRef = useRef(false);
-	const navigation = useNavigation<any>();
+	const { handleFetchCards } = useCardList();
 
 	/** qr코드 Base64 인코딩 후 파일 저장 및 외부로 공유하는 함수 */
 	const shareQR = async () => {
-		console.log('qr 공유 중...');
 		qrRef.current?.toDataURL(async (data: string) => {
 			const filename = FileSystem.documentDirectory + 'scannect_qrcode.png';
 			await FileSystem.writeAsStringAsync(filename, data, {
@@ -24,7 +22,7 @@ export function useQRCode() {
 			if (await Sharing.isAvailableAsync()) {
 				await Sharing.shareAsync(filename);
 			} else {
-				Alert.alert('공유 실패', '잠시 후 다시 시도해주세요.');
+				console.error('qr 외부 공유 불가');
 			}
 		});
 	};
@@ -32,51 +30,31 @@ export function useQRCode() {
 	/** 바코드 스캔 상태 초기화 함수 */
 	const resetScan = () => (scannedRef.current = false);
 
-	/** 스캔한 명함을 저장하고 해당 명함 상세 페이지로 이동하는 함수 */
-	const handleSaveQRCard = async (cardId: number) => {
+	/** 스캔한 명함 저장 함수 */
+	const saveQRCard = async (cardId: number) => {
 		try {
 			const userId = await getUserId(); // id: tester, password: 123456
 			if (!userId) throw new Error('로그인 정보 없음');
 
-			/* 명함 저장 */
-			await saveQRCard(userId, cardId);
-
-			/* 네비게이션 */
-			navigation.pop();
-			navigation.navigate('CardListTab', { screen: 'CardDetail', params: { cardId } });
+			/* 명함 저장 후 새로 불러오기 */
+			await saveCard(userId, cardId);
+			await handleFetchCards(false);
+			return true;
 		} catch (e) {
 			console.error('명함 저장 실패', e);
 			return false;
 		}
 	};
 
-	/** 바코드 스캔 데이터 저장 함수 */
+	/** 바코드 스캔 함수 */
 	const scanQR = (data: string) => {
-		if (scannedRef.current) return;
+		if (scannedRef.current) return { dupScanned: true, validate: false };
 		scannedRef.current = true;
 
 		// qr코드 유효성 검사
-		if (!data.startsWith('scannect://')) {
-			Alert.alert('유효하지 않은 QR 코드입니다.', '정확한 명함 QR을 인식해주세요!', [
-				{
-					text: '확인',
-					onPress: resetScan,
-				},
-			]);
-		} else {
-			// 링크 url에서 cardId 정보 get
-			const parsedURL = data.split('/');
-			const scannedCardId = parseInt(parsedURL[parsedURL.length - 1]);
-
-			Alert.alert(`명함 스캔 완료! id: ${scannedCardId}`, '스캔한 명함을 저장합니다...', [
-				{
-					text: '저장',
-					onPress: () => handleSaveQRCard(scannedCardId),
-				},
-				{ text: '취소', onPress: resetScan },
-			]);
-		}
+		if (data.startsWith('scannect://')) return { dupScanned: false, validate: true };
+		else return { dupScanned: false, validate: false };
 	};
 
-	return { qrRef, shareQR, scanQR };
+	return { qrRef, resetScan, shareQR, scanQR, saveQRCard };
 }

--- a/src/screens/Exchange/QRGenerationView.tsx
+++ b/src/screens/Exchange/QRGenerationView.tsx
@@ -1,4 +1,4 @@
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, Alert } from 'react-native';
 
 import ScreenContainer from '../../components/ScreenContainer';
 import QRCodeSection from '../../components/qrcode/QRCodeSection';
@@ -7,22 +7,28 @@ import spacing from '../../styles/spacing';
 import colors from '../../styles/Colors';
 import { useMypageStore } from '../../store/useMyPageStore';
 
-export default function QRGenerationView() {
-	const exampleID = 1; // QR 생성을 위한 id 데이터
-	const qrUrl = `scannect://cardlist-tab/card-detail/${exampleID}`; // url은 컨벤션상 kebab-case로 작성 -> 인식하려면 Navigation Linking 설정 필요
-	const { selectedCard } = useMypageStore();
+export default function QRGenerationView({ navigation }: any) {
+	const { selectedCard: card } = useMypageStore();
+	const qrUrl = `scannect://cardlist-tab/card-detail/${card?.id}`; // 명함 id
+
+	if (!card) {
+		Alert.alert('공유할 수 있는 명함이 없습니다!', '확인 후 다시 시도해주세요.', [
+			{
+				text: '확인',
+				onPress: () => navigation.goBack(),
+			},
+		]);
+	}
 
 	return (
 		<ScreenContainer>
 			<View style={styles.container}>
 				<View style={styles.textWrapper}>
-					<Text style={commonStyles.subtitleText}>나의 기본명함으로 QR코드를 만들었어요.</Text>
+					<Text style={commonStyles.subtitleText}>내 명함으로 QR코드를 만들었어요.</Text>
 					<Text style={commonStyles.bodyBoldText}>
 						이제 나만의 명함을 저장하고 공유할 수 있어요.
 					</Text>
-					<Text style={[commonStyles.captionText, styles.exchangedCardInfo]}>
-						{selectedCard?.title}
-					</Text>
+					<Text style={[commonStyles.captionText, styles.exchangedCardInfo]}>{card?.cardName}</Text>
 				</View>
 				<QRCodeSection value={qrUrl} />
 			</View>
@@ -46,7 +52,7 @@ const styles = StyleSheet.create({
 	exchangedCardInfo: {
 		position: 'absolute',
 		top: -40,
-		left: 30,
+		left: 0,
 		backgroundColor: colors.paleGreen,
 		paddingVertical: spacing.s,
 		paddingHorizontal: spacing.sm,

--- a/src/screens/Exchange/QRScanView.tsx
+++ b/src/screens/Exchange/QRScanView.tsx
@@ -1,16 +1,49 @@
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, Alert } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import React, { useEffect } from 'react';
 
 import { useQRCode } from '../../hooks/useQRCode';
 import CommonButton from '../../components/CommonButton';
 
-export default function QRScanView() {
-	const { scanQR } = useQRCode();
+export default function QRScanView({ navigation }: any) {
+	const { scanQR, resetScan, saveQRCard } = useQRCode();
 	const [permission, requestPermission] = useCameraPermissions();
 
+	const handleSaveQRCard = async (cardId: number) => {
+		const success = await saveQRCard(cardId);
+		if (!success) {
+			Alert.alert('처리 실패', '잠시 후 다시 시도해주세요.');
+			resetScan();
+		} else {
+			/* 네비게이션 */
+			navigation.pop();
+			navigation.navigate('CardListTab', { screen: 'CardDetail', params: { cardId } });
+		}
+	};
+
 	const handleBarcodeScanned = ({ data }: { data: string }) => {
-		scanQR(data);
+		const { dupScanned, validate } = scanQR(data);
+		if (dupScanned) return;
+		if (!validate) {
+			Alert.alert('유효하지 않은 QR 코드입니다.', '정확한 명함 QR을 인식해주세요!', [
+				{
+					text: '확인',
+					onPress: resetScan,
+				},
+			]);
+		} else {
+			// 링크 url에서 cardId 정보 get
+			const paths = new URL(data).pathname.split('/');
+			const scannedCardId = Number(paths.pop());
+
+			Alert.alert('명함 스캔 완료!', '스캔한 명함을 저장합니다...', [
+				{
+					text: '저장',
+					onPress: () => handleSaveQRCard(scannedCardId),
+				},
+				{ text: '취소', onPress: resetScan },
+			]);
+		}
 	};
 
 	useEffect(() => {

--- a/src/screens/Exchange/QRScanView.tsx
+++ b/src/screens/Exchange/QRScanView.tsx
@@ -1,21 +1,24 @@
-import { Text, View, StyleSheet, Alert } from 'react-native';
+import { Text, View, StyleSheet, Alert, ActivityIndicator } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useQRCode } from '../../hooks/useQRCode';
 import CommonButton from '../../components/CommonButton';
 
 export default function QRScanView({ navigation }: any) {
 	const { scanQR, resetScan, saveQRCard } = useQRCode();
+	const [isLoading, setIsLoading] = useState(false);
 	const [permission, requestPermission] = useCameraPermissions();
 
 	const handleSaveQRCard = async (cardId: number) => {
+		setIsLoading(true);
 		const success = await saveQRCard(cardId);
+		setIsLoading(false);
+
 		if (!success) {
 			Alert.alert('처리 실패', '잠시 후 다시 시도해주세요.');
 			resetScan();
 		} else {
-			/* 네비게이션 */
 			navigation.pop();
 			navigation.navigate('CardListTab', { screen: 'CardDetail', params: { cardId } });
 		}
@@ -32,7 +35,6 @@ export default function QRScanView({ navigation }: any) {
 				},
 			]);
 		} else {
-			// 링크 url에서 cardId 정보 get
 			const paths = new URL(data).pathname.split('/');
 			const scannedCardId = Number(paths.pop());
 
@@ -61,6 +63,14 @@ export default function QRScanView({ navigation }: any) {
 		);
 	}
 
+	function LoadingView() {
+		return (
+			<View style={styles.loadingOverlay}>
+				<ActivityIndicator size="small" color="#ffffff" />
+			</View>
+		);
+	}
+
 	return (
 		<View style={styles.container}>
 			<CameraView
@@ -70,6 +80,7 @@ export default function QRScanView({ navigation }: any) {
 					barcodeTypes: ['qr'],
 				}}
 			/>
+			{isLoading && <LoadingView />}
 		</View>
 	);
 }
@@ -83,5 +94,15 @@ const styles = StyleSheet.create({
 	scanner: {
 		width: '100%',
 		height: '100%',
+	},
+	loadingOverlay: {
+		position: 'absolute',
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		justifyContent: 'center',
+		alignItems: 'center',
+		backgroundColor: 'rgba(0, 0, 0, 0.3)',
 	},
 });

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const BASE_URL = 'https://scannect-be.onrender.com/api';
-const DEFAULT_TIMEOUT = 10000;
+const DEFAULT_TIMEOUT = 5000;
 
 export const createClient = () => {
 	const axiosInstance = axios.create({

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const BASE_URL = 'https://scannect-be.onrender.com/api';
-const DEFAULT_TIMEOUT = 3000;
+const DEFAULT_TIMEOUT = 10000;
 
 export const createClient = () => {
 	const axiosInstance = axios.create({

--- a/src/server/qrcode.ts
+++ b/src/server/qrcode.ts
@@ -1,11 +1,11 @@
 import { httpClient } from './http';
 
-const defaultData = {
+const DEFAULT_DATA = {
 	favorite: false,
 	memo: '',
 	isActive: true,
 };
 
 export const saveCard = async (userId: string, cardId: number) => {
-	await httpClient.post(`/card-list`, { userId, cardId, ...defaultData });
+	await httpClient.post(`/card-list`, { userId, cardId, ...DEFAULT_DATA });
 };

--- a/src/server/qrcode.ts
+++ b/src/server/qrcode.ts
@@ -1,0 +1,11 @@
+import { httpClient } from './http';
+
+const defaultData = {
+	favorite: false,
+	memo: '',
+	isActive: true,
+};
+
+export const saveCard = async (userId: string, cardId: number) => {
+	await httpClient.post(`/card-list`, { userId, cardId, ...defaultData });
+};


### PR DESCRIPTION
## 📝 작업 내용

- QR 교환을 위한 명함 저장 API를 연동했습니다.
- `server/qrcode`에 네트워크 로직을, `hooks/useQRCode`에 비즈니스 로직을 정리했습니다.
- `useQRCode` 훅에서 처리하던 UI 동작들(`alert`, `navigation`)을 컴포넌트에서 처리하도록 코드를 수정했습니다.

- QR 생성에 사용하던 임시 id를 실제 `card.id`로 변경했습니다.
- 스캔 후 명함 저장 및 명함 리스트 refetching 중에 보여줄 `LoadingView`를 구현했습니다.

- axios `timeout` 값을 최대 5초로 늘렸습니다.

## 💬 기타 사항

- api 호출이 잘 될 때는 빨리빨리 응답이 오는데, 특히 명함 리스트나 검색 결과 같이 데이터 배열을 받아오는 경우에는 상대적으로 응답 속도가 느려서 혹시 몰라 타임아웃 기준을 조금 늘렸습니다.

---
Closes #45 
